### PR TITLE
Add support for deterministic sender_id computation using public keys; enable ALPN-based role negotiation and mutual TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +368,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +403,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -516,6 +586,12 @@ checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jni"
@@ -697,6 +773,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -991,6 +1076,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1306,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1229,6 +1324,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1278,10 +1384,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1289,6 +1397,16 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -1318,7 +1436,19 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1764,6 +1894,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 quinn = "0.11.8"
 rustls = "0.23.29"
 serde = { version = "1.0.219", features = ["derive"] }
-tokio = "1.46.1"
+tokio = { version = "1.46.1", features = ["macros", "rt-multi-thread"] }
 uuid = { version = "1.17.0", features = ["v4"] }
 rcgen = "0.14.2"
 ark-ff = "0.5.0"
@@ -16,3 +16,4 @@ async-trait = "0.1.88"
 bincode = "1.3.3"
 tracing = "0.1.41"
 dashmap = "7.0.0-rc2"
+x509-parser = "0.16"

--- a/src/transports/net_envelope.rs
+++ b/src/transports/net_envelope.rs
@@ -5,10 +5,9 @@ use serde::{Deserialize, Serialize};
 /// the consumer must treat the bytes as a raw HoneyBadger WrappedMessage payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum NetEnvelope {
-    /// Binary encoded handshake used for future extensibility. Current QUIC impl
-    /// still uses a text-line handshake on the first stream, but we support this
-    /// for forward-compatibility.
-    Handshake { role: String, id: usize },
+    /// Binary encoded handshake for PartyId/ClientId exchange.
+    /// Role identification is now done via ALPN protocol negotiation.
+    Handshake { id: usize },
     /// Raw HoneyBadger message bytes (bincode of WrappedMessage from mpc crate).
     HoneyBadger(Vec<u8>),
 }

--- a/src/transports/quic.rs
+++ b/src/transports/quic.rs
@@ -14,14 +14,24 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use dashmap::{DashMap, DashSet};
-use crate::network_utils::{ClientId, ClientType, Message, Network, NetworkError, Node, PartyId};
+use crate::network_utils::{ClientId, ClientType, Message, Network, NetworkError, Node, NodePublicKey, PartyId};
 use tokio::sync::{Mutex, mpsc};
 use ark_ff::Field;
 use async_trait::async_trait;
 use uuid::Uuid;
 use std::time::Duration;
-use crate::transports::net_envelope::NetEnvelope;
-use tracing::{debug, info, warn};
+// Note: NetEnvelope is no longer needed for handshakes since IDs are derived from public keys
+use tracing::{debug, info, warn, trace};
+use x509_parser::prelude::*;
+
+// ============================================================================
+// ALPN PROTOCOL IDENTIFIERS
+// ============================================================================
+
+/// ALPN protocol identifier for CLIENT role connections
+const ALPN_CLIENT_PROTOCOL: &[u8] = b"client-protocol";
+/// ALPN protocol identifier for SERVER role connections
+const ALPN_SERVER_PROTOCOL: &[u8] = b"server-protocol";
 
 // ============================================================================
 // CONNECTION STATE
@@ -257,6 +267,8 @@ pub struct QuicPeerConnection {
     /// Connection state
     state: Arc<Mutex<ConnectionState>>,
     connection_role: ClientType,
+    /// Peer's public key extracted from TLS certificate
+    peer_public_key: Option<NodePublicKey>,
 }
 
 impl QuicPeerConnection {
@@ -266,6 +278,7 @@ impl QuicPeerConnection {
         send: quinn::SendStream,
         recv: quinn::RecvStream,
         connection_role: ClientType,
+        peer_public_key: Option<NodePublicKey>,
     ) -> Self {
         let remote_addr = connection.remote_address();
         Self {
@@ -275,6 +288,7 @@ impl QuicPeerConnection {
             recv_stream: Arc::new(Mutex::new(recv)),
             state: Arc::new(Mutex::new(ConnectionState::Connected)),
             connection_role,
+            peer_public_key,
         }
     }
 
@@ -282,6 +296,7 @@ impl QuicPeerConnection {
     pub async fn new_with_connection(
         connection: Connection,
         connection_role: ClientType,
+        peer_public_key: Option<NodePublicKey>,
     ) -> Result<Self, ConnectionError> {
         let remote_addr = connection.remote_address();
         let (send, recv) = connection
@@ -298,7 +313,13 @@ impl QuicPeerConnection {
             recv_stream: Arc::new(Mutex::new(recv)),
             state: Arc::new(Mutex::new(ConnectionState::Connected)),
             connection_role,
+            peer_public_key,
         })
+    }
+
+    /// Returns the peer's public key if available
+    pub fn get_peer_public_key(&self) -> Option<&NodePublicKey> {
+        self.peer_public_key.as_ref()
     }
 
     /// Updates connection state
@@ -567,41 +588,72 @@ impl PeerConnection for LoopbackPeerConnection {
 }
 
 // ============================================================================
-// HANDSHAKE HELPERS
+// STREAM SYNCHRONIZATION
 // ============================================================================
 
-/// Sends a handshake envelope over a stream
-async fn send_handshake(
-    send: &mut quinn::SendStream,
-    role: &str,
-    id: usize,
-) -> Result<(), ConnectionError> {
-    let envelope = NetEnvelope::Handshake {
-        role: role.to_string(),
-        id,
-    };
-    let bytes = envelope.serialize();
-    send_framed_message(send, &bytes).await
+/// Sync byte sent by the initiator to establish the bidirectional stream
+const STREAM_SYNC_BYTE: u8 = 0xFF;
+
+/// Sends a sync byte to establish the stream (called by connection initiator)
+async fn send_stream_sync(send: &mut quinn::SendStream) -> Result<(), ConnectionError> {
+    send.write_all(&[STREAM_SYNC_BYTE])
+        .await
+        .map_err(|e| ConnectionError::SendFailed(format!("Failed to send sync: {}", e)))
 }
 
-/// Receives a handshake envelope from a stream
-async fn recv_handshake(
-    recv: &mut quinn::RecvStream,
-) -> Result<Option<(String, usize)>, ConnectionError> {
-    let bytes = recv_framed_message(recv).await?;
+/// Receives the sync byte to acknowledge stream establishment (called by connection acceptor)
+async fn recv_stream_sync(recv: &mut quinn::RecvStream) -> Result<(), ConnectionError> {
+    let mut buf = [0u8; 1];
+    recv.read_exact(&mut buf)
+        .await
+        .map_err(|e| match e {
+            quinn::ReadExactError::FinishedEarly(_) => ConnectionError::StreamClosed,
+            quinn::ReadExactError::ReadError(re) => {
+                ConnectionError::ReceiveFailed(format!("Failed to receive sync: {}", re))
+            }
+        })?;
 
-    match NetEnvelope::try_deserialize(&bytes) {
-        Ok(NetEnvelope::Handshake { role, id }) => Ok(Some((role, id))),
-        Ok(NetEnvelope::HoneyBadger(_)) => Ok(None), // Legacy, no handshake
-        Err(_) => Ok(None), // Not an envelope, legacy path
+    if buf[0] != STREAM_SYNC_BYTE {
+        return Err(ConnectionError::FramingError(
+            format!("Invalid sync byte: expected {:#x}, got {:#x}", STREAM_SYNC_BYTE, buf[0])
+        ));
     }
+
+    Ok(())
 }
 
-fn client_type_from_role(role: &str) -> ClientType {
-    if role.eq_ignore_ascii_case("CLIENT") {
-        ClientType::Client
-    } else {
-        ClientType::Server
+// ============================================================================
+// ALPN HELPERS
+// ============================================================================
+
+/// Extracts the negotiated ALPN protocol from a QUIC connection and returns the ClientType
+fn extract_alpn_role(connection: &Connection) -> Result<ClientType, String> {
+    let handshake_data = connection
+        .handshake_data()
+        .ok_or_else(|| "No handshake data available".to_string())?;
+
+    let handshake = handshake_data
+        .downcast::<quinn::crypto::rustls::HandshakeData>()
+        .map_err(|_| "Failed to downcast handshake data to rustls type".to_string())?;
+
+    match handshake.protocol.as_ref().map(|v| v.as_slice()) {
+        Some(proto) if proto == ALPN_CLIENT_PROTOCOL => {
+            trace!("ALPN negotiated: client-protocol");
+            Ok(ClientType::Client)
+        }
+        Some(proto) if proto == ALPN_SERVER_PROTOCOL => {
+            trace!("ALPN negotiated: server-protocol");
+            Ok(ClientType::Server)
+        }
+        Some(proto) => {
+            let proto_str = String::from_utf8_lossy(proto);
+            warn!("Unknown ALPN protocol: {}", proto_str);
+            Err(format!("Unknown ALPN protocol: {}", proto_str))
+        }
+        None => {
+            warn!("No ALPN protocol negotiated");
+            Err("No ALPN protocol negotiated".to_string())
+        }
     }
 }
 
@@ -714,6 +766,14 @@ pub struct QuicNetworkManager {
     client_connections: Arc<DashMap<ClientId, Arc<dyn PeerConnection>>>,
     /// Replaced Mutex<HashSet> with DashSet for client IDs
     client_ids: Arc<DashSet<ClientId>>,
+    /// Persistent certificate for this node (generated once)
+    /// Stored as DER-encoded certificate and private key
+    local_cert_der: Option<Vec<u8>>,
+    local_key_der: Option<Vec<u8>>,
+    /// This node's public key (derived from local_certificate)
+    local_public_key: Option<NodePublicKey>,
+    /// Connected peers' public keys (for sender_id computation)
+    peer_public_keys: Arc<DashMap<PartyId, NodePublicKey>>,
 }
 
 impl Default for QuicNetworkManager {
@@ -733,6 +793,10 @@ impl QuicNetworkManager {
             connections: Arc::new(DashMap::new()),
             client_connections: Arc::new(DashMap::new()),
             client_ids: Arc::new(DashSet::new()),
+            local_cert_der: None,
+            local_key_der: None,
+            local_public_key: None,
+            peer_public_keys: Arc::new(DashMap::new()),
         }
     }
 
@@ -807,13 +871,43 @@ impl QuicNetworkManager {
     }
 
     /// Creates insecure client config (for development only)
-    fn create_insecure_client_config() -> Result<ClientConfig, String> {
-        let mut crypto = rustls::ClientConfig::builder()
-            .dangerous()
-            .with_custom_certificate_verifier(Arc::new(SkipServerVerification::new()))
-            .with_no_client_auth();
+    /// The role parameter determines which ALPN protocol to advertise:
+    /// - ClientType::Client -> ALPN_CLIENT_PROTOCOL
+    /// - ClientType::Server -> ALPN_SERVER_PROTOCOL
+    ///
+    /// If cert_der and key_der are provided, the client will present a certificate
+    /// during TLS handshake (mutual TLS).
+    fn create_insecure_client_config(
+        role: ClientType,
+        cert_der: Option<&[u8]>,
+        key_der: Option<&[u8]>,
+    ) -> Result<ClientConfig, String> {
+        let mut crypto = match (cert_der, key_der) {
+            (Some(cert), Some(key)) => {
+                // Mutual TLS: client presents certificate
+                let cert_chain = vec![CertificateDer::from(cert.to_vec())];
+                let private_key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key.to_vec()));
 
-        crypto.alpn_protocols = vec![b"quic-example".to_vec()];
+                rustls::ClientConfig::builder()
+                    .dangerous()
+                    .with_custom_certificate_verifier(Arc::new(SkipServerVerification::new()))
+                    .with_client_auth_cert(cert_chain, private_key)
+                    .map_err(|e| format!("Failed to configure client certificate: {}", e))?
+            }
+            _ => {
+                // No client certificate
+                rustls::ClientConfig::builder()
+                    .dangerous()
+                    .with_custom_certificate_verifier(Arc::new(SkipServerVerification::new()))
+                    .with_no_client_auth()
+            }
+        };
+
+        // Set ALPN based on role
+        crypto.alpn_protocols = match role {
+            ClientType::Client => vec![ALPN_CLIENT_PROTOCOL.to_vec()],
+            ClientType::Server => vec![ALPN_SERVER_PROTOCOL.to_vec()],
+        };
 
         let mut config = ClientConfig::new(Arc::new(
             quinn::crypto::rustls::QuicClientConfig::try_from(crypto)
@@ -831,22 +925,27 @@ impl QuicNetworkManager {
         Ok(config)
     }
 
-    /// Creates self-signed server config (for development only)
-    fn create_self_signed_server_config() -> Result<ServerConfig, String> {
-        let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])
-            .map_err(|e| format!("Failed to generate certificate: {}", e))?;
-
-        let cert_der = CertificateDer::from(cert.cert.der().to_vec());
+    /// Creates self-signed server config using provided DER-encoded certificate and key.
+    /// Accepts both ALPN_SERVER_PROTOCOL and ALPN_CLIENT_PROTOCOL for incoming connections.
+    /// Requests (but doesn't require) client certificates for mutual TLS.
+    fn create_self_signed_server_config(cert_der_bytes: &[u8], key_der_bytes: &[u8]) -> Result<ServerConfig, String> {
+        let cert_der = CertificateDer::from(cert_der_bytes.to_vec());
         let key_der = PrivateKeyDer::Pkcs8(
-            PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der())
+            PrivatePkcs8KeyDer::from(key_der_bytes.to_vec())
         );
 
+        // Use custom client cert verifier that accepts all client certificates
+        // This enables mutual TLS where clients can optionally present certificates
         let mut server_crypto = rustls::ServerConfig::builder()
-            .with_no_client_auth()
+            .with_client_cert_verifier(SkipClientVerification::new())
             .with_single_cert(vec![cert_der], key_der)
             .map_err(|e| format!("Failed to create server crypto config: {}", e))?;
 
-        server_crypto.alpn_protocols = vec![b"quic-example".to_vec()];
+        // Accept both ALPN protocols for incoming connections
+        server_crypto.alpn_protocols = vec![
+            ALPN_SERVER_PROTOCOL.to_vec(),
+            ALPN_CLIENT_PROTOCOL.to_vec(),
+        ];
 
         let mut server_config = ServerConfig::with_crypto(Arc::new(
             quinn::crypto::rustls::QuicServerConfig::try_from(server_crypto)
@@ -861,10 +960,18 @@ impl QuicNetworkManager {
         Ok(server_config)
     }
 
-    /// Ensures endpoint is initialized with client config
-    async fn ensure_client_endpoint(&mut self) -> Result<(), String> {
+    /// Ensures endpoint is initialized with client config for the specified role.
+    /// Also ensures a local certificate exists for mutual TLS.
+    async fn ensure_client_endpoint(&mut self, role: ClientType) -> Result<(), String> {
+        // Ensure we have a local certificate for mTLS
+        self.ensure_local_certificate()?;
+
         if self.endpoint.is_none() {
-            let client_config = Self::create_insecure_client_config()?;
+            let client_config = Self::create_insecure_client_config(
+                role,
+                self.local_cert_der.as_deref(),
+                self.local_key_der.as_deref(),
+            )?;
             let mut endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap())
                 .map_err(|e| format!("Failed to create client endpoint: {}", e))?;
             endpoint.set_default_client_config(client_config);
@@ -873,16 +980,176 @@ impl QuicNetworkManager {
         Ok(())
     }
 
-    /// Connects and sends a CLIENT handshake
-    /// Returns Arc<dyn PeerConnection> for actor model compatibility
-    /// Connects and sends a CLIENT handshake
-    /// Returns Arc<dyn PeerConnection> for actor model compatibility
+    // ============================================================================
+    // CERTIFICATE AND PUBLIC KEY MANAGEMENT
+    // ============================================================================
+
+    /// Ensures a local certificate is generated and stored as DER bytes.
+    fn ensure_local_certificate(&mut self) -> Result<(), String> {
+        if self.local_cert_der.is_none() {
+            let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])
+                .map_err(|e| format!("Failed to generate certificate: {}", e))?;
+
+            // Store DER-encoded certificate and key
+            let cert_der = cert.cert.der().to_vec();
+            let key_der = cert.signing_key.serialize_der();
+
+            // Extract and store public key
+            let public_key = Self::extract_public_key_from_cert(&cert_der)?;
+            self.local_public_key = Some(public_key);
+
+            self.local_cert_der = Some(cert_der);
+            self.local_key_der = Some(key_der);
+            trace!("Generated and stored local certificate");
+        }
+        Ok(())
+    }
+
+    /// Extracts the SubjectPublicKeyInfo (SPKI) from a DER-encoded X.509 certificate
+    fn extract_public_key_from_cert(cert_der: &[u8]) -> Result<NodePublicKey, String> {
+        let (_, cert) = X509Certificate::from_der(cert_der)
+            .map_err(|e| format!("Failed to parse X.509 certificate: {:?}", e))?;
+
+        // Get the SubjectPublicKeyInfo in DER format
+        let spki = cert.public_key();
+        let spki_der = spki.raw.to_vec();
+
+        Ok(NodePublicKey(spki_der))
+    }
+
+    /// Extracts the peer's public key from a QUIC connection's TLS certificate chain
+    fn extract_peer_public_key(connection: &Connection) -> Result<NodePublicKey, String> {
+        let peer_identity = connection
+            .peer_identity()
+            .ok_or_else(|| "No peer identity available".to_string())?;
+
+        let certs = peer_identity
+            .downcast::<Vec<CertificateDer<'static>>>()
+            .map_err(|_| "Failed to downcast peer identity to certificate chain".to_string())?;
+
+        if certs.is_empty() {
+            return Err("Peer certificate chain is empty".to_string());
+        }
+
+        // Extract public key from the first (end-entity) certificate
+        Self::extract_public_key_from_cert(&certs[0])
+    }
+
+    // ============================================================================
+    // SENDER_ID COMPUTATION
+    // ============================================================================
+
+    /// Returns a sorted list of all public keys (local + peers).
+    /// The position in this list corresponds to the sender_id (0..N-1).
+    pub fn get_sorted_public_keys(&self) -> Vec<NodePublicKey> {
+        let mut all_keys: Vec<NodePublicKey> = Vec::new();
+
+        // Add local public key
+        if let Some(ref local_pk) = self.local_public_key {
+            all_keys.push(local_pk.clone());
+        }
+
+        // Add peer public keys
+        for entry in self.peer_public_keys.iter() {
+            all_keys.push(entry.value().clone());
+        }
+
+        // Sort lexicographically by DER bytes
+        all_keys.sort_by(|a, b| a.0.cmp(&b.0));
+        all_keys
+    }
+
+    /// Gets the public key for a given sender_id (0..N-1).
+    /// Returns None if sender_id is out of range.
+    pub fn get_public_key_for_sender_id(&self, sender_id: PartyId) -> Option<NodePublicKey> {
+        let sorted_keys = self.get_sorted_public_keys();
+        sorted_keys.get(sender_id).cloned()
+    }
+
+    /// Gets the sender_id (0..N-1) for a given public key.
+    /// Returns None if the public key is not known.
+    pub fn get_sender_id_for_public_key(&self, pk: &NodePublicKey) -> Option<PartyId> {
+        let sorted_keys = self.get_sorted_public_keys();
+        sorted_keys.iter().position(|k| k == pk).map(|pos| pos as PartyId)
+    }
+
+    /// Gets the connection for a given sender_id (0..N-1).
+    /// For MPC protocols, use this instead of direct connection lookup.
+    pub fn get_connection_by_sender_id(&self, sender_id: PartyId) -> Option<Arc<dyn PeerConnection>> {
+        let pk = self.get_public_key_for_sender_id(sender_id)?;
+
+        // Check if this is our own public key (loopback)
+        if Some(&pk) == self.local_public_key.as_ref() {
+            return self.connections.get(&self.node_id).map(|r| r.value().clone());
+        }
+
+        // Find the connection for this peer's public key
+        let derived_id = pk.derive_id();
+        self.connections.get(&derived_id).map(|r| r.value().clone())
+    }
+
+    /// Computes the sender_id by sorting all public keys (local + peers) lexicographically
+    /// and returning this node's position in the sorted list.
+    /// Returns None if local_public_key is not set.
+    pub fn compute_sender_id(&self) -> Option<PartyId> {
+        let local_pk = self.local_public_key.as_ref()?;
+        self.get_sender_id_for_public_key(local_pk)
+    }
+
+    /// Returns the computed sender_id, falling back to node_id if not computable
+    pub fn sender_id(&self) -> PartyId {
+        self.compute_sender_id().unwrap_or(self.node_id)
+    }
+
+    /// Checks if we have public keys from all expected parties
+    pub fn is_fully_connected(&self, expected_count: usize) -> bool {
+        // We need (expected_count - 1) peers since we don't count ourselves
+        self.peer_public_keys.len() >= expected_count.saturating_sub(1)
+            && self.local_public_key.is_some()
+    }
+
+    /// Returns the finalized sender_id only if fully connected to all expected parties
+    pub fn finalized_sender_id(&self, expected_count: usize) -> Option<PartyId> {
+        if self.is_fully_connected(expected_count) {
+            self.compute_sender_id()
+        } else {
+            None
+        }
+    }
+
+    /// Returns the number of parties (local + peers)
+    pub fn party_count(&self) -> usize {
+        let local_count = if self.local_public_key.is_some() { 1 } else { 0 };
+        local_count + self.peer_public_keys.len()
+    }
+
+    /// Returns a reference to this node's public key
+    pub fn get_public_key(&self) -> Option<&NodePublicKey> {
+        self.local_public_key.as_ref()
+    }
+
+    /// Returns the node_id (legacy ID, used as fallback)
+    pub fn get_node_id(&self) -> PartyId {
+        self.node_id
+    }
+
+    /// Returns the ID derived from this node's public key.
+    /// Falls back to node_id if no certificate has been generated yet.
+    pub fn local_derived_id(&self) -> PartyId {
+        self.local_public_key
+            .as_ref()
+            .map(|pk| pk.derive_id())
+            .unwrap_or(self.node_id)
+    }
+
+    /// Connects as a CLIENT to a server (role identified via ALPN).
+    /// The server's ID is derived from its public key.
+    /// Returns Arc<dyn PeerConnection> for actor model compatibility.
     pub async fn connect_as_client(
         &mut self,
         address: SocketAddr,
-        client_id: ClientId,
     ) -> Result<Arc<dyn PeerConnection>, String> {
-        self.ensure_client_endpoint().await?;
+        self.ensure_client_endpoint(ClientType::Client).await?;
         self.ensure_loopback_installed().await;
 
         let endpoint = self.endpoint.as_ref().unwrap();
@@ -892,42 +1159,40 @@ impl QuicNetworkManager {
             .await
             .map_err(|e| format!("Failed to establish connection: {}", e))?;
 
-        // Open persistent stream and send handshake
-        let (mut send, mut recv) = connection.open_bi().await
+        // Verify ALPN negotiation resulted in client-protocol
+        let connection_role = extract_alpn_role(&connection).unwrap_or_else(|e| {
+            warn!("ALPN extraction failed: {}, defaulting to Server", e);
+            ClientType::Server
+        });
+
+        // Extract peer's public key from TLS certificate
+        let peer_public_key = Self::extract_peer_public_key(&connection).ok();
+
+        // Open persistent stream and send sync byte to establish it
+        let (mut send, recv) = connection.open_bi().await
             .map_err(|e| format!("Failed to open stream: {}", e))?;
 
-        send_handshake(&mut send, "CLIENT", client_id).await
-            .map_err(|e| format!("Failed to send handshake: {}", e))?;
+        send_stream_sync(&mut send).await
+            .map_err(|e| format!("Failed to sync stream: {}", e))?;
 
-        // Receive server's handshake response to get its PartyId
-        let server_handshake = recv_handshake(&mut recv).await
-            .map_err(|e| format!("Failed to receive server handshake: {}", e))?;
-
-        let mut connection_role = ClientType::Server;
-        // Determine the correct party_id to use
-        let party_id = if let Some((role, id)) = server_handshake {
-            connection_role = client_type_from_role(&role);
-            if role.eq_ignore_ascii_case("SERVER") {
-                // Server told us its PartyId - use it!
-                info!("Client {} connected to server with PartyId {}", client_id, id);
-
-                // Ensure node exists with this party_id
-                // if !self.nodes.iter().any(|n| n.id() == id) {
-                let node = QuicNode::from_party_id(id, address);
-                self.nodes.push(node);
-                // }
-
-                id
-            } else {
-                // Unexpected role, fallback to address-based lookup
-                warn!("Unexpected handshake role from server: {}", role);
-                self.fallback_node_lookup(address)
-            }
+        // Derive server's ID from its public key
+        let server_id = if let Some(ref pk) = peer_public_key {
+            pk.derive_id()
         } else {
-            // No handshake received, fallback to address-based lookup
-            warn!("No handshake received from server at {}", address);
+            warn!("Could not extract server public key from {}, using address-based ID", address);
             self.fallback_node_lookup(address)
         };
+
+        // Store peer's public key if available
+        if let Some(ref pk) = peer_public_key {
+            self.peer_public_keys.insert(server_id, pk.clone());
+            trace!("Stored public key for server {}", server_id);
+        }
+
+        // Ensure node exists
+        if !self.nodes.iter().any(|n| n.id() == server_id) {
+            self.nodes.push(QuicNode::from_party_id(server_id, address));
+        }
 
         // Create Arc-wrapped connection
         let conn = Arc::new(QuicPeerConnection::new(
@@ -935,11 +1200,17 @@ impl QuicNetworkManager {
             send,
             recv,
             connection_role,
+            peer_public_key,
         )) as Arc<dyn PeerConnection>;
 
-        // Store connection with the correct party_id
-        self.connections.insert(party_id, Arc::clone(&conn));
-        info!("Client {} stored connection to server PartyId {} at {}", client_id, party_id, address);
+        // Store connection with the server's derived ID
+        self.connections.insert(server_id, Arc::clone(&conn));
+
+        // Log our own derived client ID for debugging
+        let client_id = self.local_public_key.as_ref()
+            .map(|pk| pk.derive_id())
+            .unwrap_or(self.node_id);
+        info!("Client {} connected to server {} at {}", client_id, server_id, address);
 
         Ok(conn)
     }
@@ -958,14 +1229,14 @@ impl QuicNetworkManager {
             })
     }
 
-    /// Connects and sends a SERVER handshake
-    /// Returns Arc<dyn PeerConnection> for actor model compatibility
+    /// Connects as a SERVER to another server (role identified via ALPN).
+    /// The peer's ID is derived from its public key.
+    /// Returns Arc<dyn PeerConnection> for actor model compatibility.
     pub async fn connect_as_server(
         &mut self,
         address: SocketAddr,
-        party_id: PartyId,
     ) -> Result<Arc<dyn PeerConnection>, String> {
-        self.ensure_client_endpoint().await?;
+        self.ensure_client_endpoint(ClientType::Server).await?;
         self.ensure_loopback_installed().await;
 
         let endpoint = self.endpoint.as_ref().unwrap();
@@ -975,33 +1246,40 @@ impl QuicNetworkManager {
             .await
             .map_err(|e| format!("Failed to establish connection: {}", e))?;
 
-        // Open persistent stream and send handshake
-        let (mut send, mut recv) = connection.open_bi().await
+        // Verify ALPN negotiation - we expect the peer to see server-protocol
+        let connection_role = extract_alpn_role(&connection).unwrap_or_else(|e| {
+            warn!("ALPN extraction failed: {}, defaulting to Server", e);
+            ClientType::Server
+        });
+
+        // Extract peer's public key from TLS certificate
+        let peer_public_key = Self::extract_peer_public_key(&connection).ok();
+
+        // Open persistent stream and send sync byte to establish it
+        let (mut send, recv) = connection.open_bi().await
             .map_err(|e| format!("Failed to open stream: {}", e))?;
 
-        send_handshake(&mut send, "SERVER", party_id).await
-            .map_err(|e| format!("Failed to send handshake: {}", e))?;
+        send_stream_sync(&mut send).await
+            .map_err(|e| format!("Failed to sync stream: {}", e))?;
 
-        let server_handshake = recv_handshake(&mut recv).await
-            .map_err(|e| format!("Failed to receive server handshake response: {}", e))?;
-
-        let mut connection_role = ClientType::Server;
-        // Find or create node and store connection
-        let node_id = if let Some((role, id)) = server_handshake {
-            connection_role = client_type_from_role(&role);
-            if role.eq_ignore_ascii_case("SERVER") {
-                if !self.nodes.iter().any(|n| n.id() == id) {
-                    self.nodes.push(QuicNode::from_party_id(id, address));
-                }
-                id
-            } else {
-                warn!("Unexpected handshake role '{}' from server at {}", role, address);
-                self.fallback_node_lookup(address)
-            }
+        // Derive peer's ID from its public key
+        let peer_id = if let Some(ref pk) = peer_public_key {
+            pk.derive_id()
         } else {
-            warn!("No handshake received from server at {}", address);
+            warn!("Could not extract peer public key from {}, using address-based ID", address);
             self.fallback_node_lookup(address)
         };
+
+        // Store peer's public key if available
+        if let Some(ref pk) = peer_public_key {
+            self.peer_public_keys.insert(peer_id, pk.clone());
+            trace!("Stored public key for peer {}", peer_id);
+        }
+
+        // Ensure node exists
+        if !self.nodes.iter().any(|n| n.id() == peer_id) {
+            self.nodes.push(QuicNode::from_party_id(peer_id, address));
+        }
 
         // Create Arc-wrapped connection
         let conn = Arc::new(QuicPeerConnection::new(
@@ -1009,9 +1287,16 @@ impl QuicNetworkManager {
             send,
             recv,
             connection_role,
+            peer_public_key,
         )) as Arc<dyn PeerConnection>;
 
-        self.connections.insert(node_id, Arc::clone(&conn));
+        self.connections.insert(peer_id, Arc::clone(&conn));
+
+        // Log our own derived ID for debugging
+        let our_id = self.local_public_key.as_ref()
+            .map(|pk| pk.derive_id())
+            .unwrap_or(self.node_id);
+        info!("Server {} connected to peer {} at {}", our_id, peer_id, address);
 
         Ok(conn)
     }
@@ -1023,7 +1308,7 @@ impl NetworkManager for QuicNetworkManager {
         address: SocketAddr,
     ) -> Pin<Box<dyn Future<Output = Result<Arc<dyn PeerConnection>, String>> + Send + 'a>> {
         Box::pin(async move {
-            self.connect_as_server(address, self.node_id).await
+            self.connect_as_server(address).await
         })
     }
 
@@ -1042,81 +1327,78 @@ impl NetworkManager for QuicNetworkManager {
 
             let remote_addr = connection.remote_address();
 
-            // Accept persistent stream and read handshake
-            let (mut send, mut recv) = connection.accept_bi().await
+            // Extract role from ALPN protocol negotiation
+            let connection_role = extract_alpn_role(&connection).unwrap_or_else(|e| {
+                warn!("ALPN extraction failed during accept: {}, defaulting to Server", e);
+                ClientType::Server
+            });
+
+            // Extract peer's public key from TLS certificate (mTLS)
+            let peer_public_key = Self::extract_peer_public_key(&connection).ok();
+
+            // Accept persistent stream and receive sync byte
+            let (send, mut recv) = connection.accept_bi().await
                 .map_err(|e| format!("Failed to accept stream: {}", e))?;
 
-            let parsed_role = recv_handshake(&mut recv).await
-                .map_err(|e| format!("Failed to read handshake: {}", e))?;
+            recv_stream_sync(&mut recv).await
+                .map_err(|e| format!("Failed to sync stream: {}", e))?;
 
-            match parsed_role {
-                Some((role, id)) if role.eq_ignore_ascii_case("CLIENT") => {
-                    // Send our party_id back to the client so it knows who we are
-                    send_handshake(&mut send, "SERVER", self.node_id).await
-                        .map_err(|e| format!("Failed to send handshake response: {}", e))?;
+            // Derive peer ID from public key, or fallback to address-based lookup
+            let peer_id = if let Some(ref pk) = peer_public_key {
+                pk.derive_id()
+            } else {
+                warn!("No peer public key available from {}, using address-based ID", remote_addr);
+                // Fallback: use address-based lookup
+                self.nodes.iter()
+                    .find(|n| n.address() == remote_addr)
+                    .map(|n| n.id())
+                    .unwrap_or_else(|| {
+                        let node = QuicNode::new_with_random_id(remote_addr);
+                        let id = node.id();
+                        self.nodes.push(node);
+                        id
+                    })
+            };
 
-                    // Create Arc-wrapped connection AFTER sending handshake
-                    let conn = Arc::new(QuicPeerConnection::new(
-                        connection.clone(),
-                        send,
-                        recv,
-                        ClientType::Client,
-                    )) as Arc<dyn PeerConnection>;
+            // Create Arc-wrapped connection
+            let conn = Arc::new(QuicPeerConnection::new(
+                connection.clone(),
+                send,
+                recv,
+                connection_role,
+                peer_public_key.clone(),
+            )) as Arc<dyn PeerConnection>;
+
+            match connection_role {
+                ClientType::Client => {
+                    // Client connection identified via ALPN
+                    info!("Accepted client connection from {} with derived ID {}", remote_addr, peer_id);
 
                     // Store as client connection
-                    self.client_connections.insert(id, Arc::clone(&conn));
-                    self.client_ids.insert(id);
-
-                    Ok(conn)
+                    self.client_connections.insert(peer_id, Arc::clone(&conn));
+                    self.client_ids.insert(peer_id);
                 }
-                Some((role, id)) if role.eq_ignore_ascii_case("SERVER") => {
-                    // Server-to-server connection: send handshake response
-                    send_handshake(&mut send, "SERVER", self.node_id).await
-                        .map_err(|e| format!("Failed to send handshake response: {}", e))?;
+                ClientType::Server => {
+                    // Server-to-server connection identified via ALPN
+                    info!("Accepted server connection from {} with derived ID {}", remote_addr, peer_id);
 
-                    // Create Arc-wrapped connection
-                    let conn = Arc::new(QuicPeerConnection::new(
-                        connection.clone(),
-                        send,
-                        recv,
-                        ClientType::Server,
-                    )) as Arc<dyn PeerConnection>;
+                    // Store peer's public key if available
+                    if let Some(pk) = peer_public_key {
+                        self.peer_public_keys.insert(peer_id, pk);
+                        trace!("Stored public key for peer {}", peer_id);
+                    }
 
                     // Ensure node exists
-                    if !self.nodes.iter().any(|n| n.id() == id) {
-                        self.nodes.push(QuicNode::from_party_id(id, remote_addr));
+                    if !self.nodes.iter().any(|n| n.id() == peer_id) {
+                        self.nodes.push(QuicNode::from_party_id(peer_id, remote_addr));
                     }
 
                     // Store connection
-                    self.connections.insert(id, Arc::clone(&conn));
-
-                    Ok(conn)
-                }
-                _ => {
-                    // Fallback: address-based mapping
-                    // Create Arc-wrapped connection
-                    let conn = Arc::new(QuicPeerConnection::new(
-                        connection.clone(),
-                        send,
-                        recv,
-                        ClientType::Server,
-                    )) as Arc<dyn PeerConnection>;
-
-                    let node_id = self.nodes.iter()
-                        .find(|n| n.address() == remote_addr)
-                        .map(|n| n.id())
-                        .unwrap_or_else(|| {
-                            let node = QuicNode::new_with_random_id(remote_addr);
-                            let id = node.id();
-                            self.nodes.push(node);
-                            id
-                        });
-
-                    self.connections.insert(node_id, Arc::clone(&conn));
-
-                    Ok(conn)
+                    self.connections.insert(peer_id, Arc::clone(&conn));
                 }
             }
+
+            Ok(conn)
         })
     }
 
@@ -1125,11 +1407,21 @@ impl NetworkManager for QuicNetworkManager {
         bind_address: SocketAddr,
     ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
         Box::pin(async move {
-            let server_config = Self::create_self_signed_server_config()?;
+            // Ensure we have a local certificate
+            self.ensure_local_certificate()?;
+            let cert_der = self.local_cert_der.as_ref().unwrap();
+            let key_der = self.local_key_der.as_ref().unwrap();
+
+            let server_config = Self::create_self_signed_server_config(cert_der, key_der)?;
             let mut endpoint = Endpoint::server(server_config, bind_address)
                 .map_err(|e| format!("Failed to create server endpoint: {}", e))?;
 
-            let client_config = Self::create_insecure_client_config()?;
+            // Default client config for outgoing connections uses Server role with mTLS
+            let client_config = Self::create_insecure_client_config(
+                ClientType::Server,
+                Some(cert_der),
+                Some(key_der),
+            )?;
             endpoint.set_default_client_config(client_config);
 
             self.endpoint = Some(endpoint);
@@ -1149,72 +1441,63 @@ impl Network for QuicNetworkManager {
     type NetworkConfig = QuicNetworkConfig;
 
     async fn send(&self, recipient: PartyId, message: &[u8]) -> Result<usize, NetworkError> {
-        if let Some(connection_ref) = self.connections.get(&recipient) {
-            let connection = connection_ref.value();
+        // Use sender_id-based lookup for MPC protocols (recipient is a sender_id 0..N-1)
+        let connection = self.get_connection_by_sender_id(recipient)
+            .ok_or(NetworkError::PartyNotFound(recipient))?;
 
-            // Check if connection is still alive
-            if !connection.is_connected().await {
-                debug!("Connection to recipient {} is dead, removing from map", recipient);
-                drop(connection_ref);
+        // Check if connection is still alive
+        if !connection.is_connected().await {
+            debug!("Connection to recipient {} is dead", recipient);
+            self.cleanup_dead_connections().await;
+            return Err(NetworkError::PartyNotFound(recipient));
+        }
+
+        match connection.send(message).await {
+            Ok(_) => {
+                debug!("Successfully sent message to recipient {}", recipient);
+                Ok(message.len())
+            }
+            Err(e) => {
+                debug!("Failed to send message to recipient {}: {}", recipient, e);
                 self.cleanup_dead_connections().await;
-                return Err(NetworkError::PartyNotFound(recipient));
+                Err(NetworkError::SendError)
             }
-
-            match connection.send(message).await {
-                Ok(_) => {
-                    debug!("Successfully sent message to recipient {}", recipient);
-                    Ok(message.len())
-                }
-                Err(e) => {
-                    debug!("Failed to send message to recipient {}: {}", recipient, e);
-                    // Connection might be dead, mark for cleanup
-                    drop(connection_ref);
-                    self.cleanup_dead_connections().await;
-                    Err(NetworkError::SendError)
-                }
-            }
-        } else {
-            Err(NetworkError::PartyNotFound(recipient))
         }
     }
 
     async fn broadcast(&self, message: &[u8]) -> Result<usize, NetworkError> {
         let mut total_bytes = 0usize;
-        let mut included_self = false;
+        let party_count = self.party_count();
 
-        for node in &self.nodes {
-            if let Some(connection_ref) = self.connections.get(&node.id()) {
-                let connection = connection_ref.value();
-
+        // Broadcast to all parties using sender_id (0..N-1)
+        for sender_id in 0..party_count {
+            if let Some(connection) = self.get_connection_by_sender_id(sender_id) {
                 // Check connection health before sending
                 if !connection.is_connected().await {
-                    debug!("Skipping broadcast to node {}: connection is dead", node.id());
+                    debug!("Skipping broadcast to sender_id {}: connection is dead", sender_id);
                     continue;
                 }
 
                 match connection.send(message).await {
                     Ok(_) => {
-                        debug!("Successfully broadcasted message to node {}", node.id());
+                        debug!("Successfully broadcasted message to sender_id {}", sender_id);
                         total_bytes += message.len();
-                        if node.id() == self.node_id {
-                            included_self = true;
-                        }
                     }
                     Err(e) => {
-                        debug!("Failed to broadcast message to node {}: {}", node.id(), e);
+                        debug!("Failed to broadcast message to sender_id {}: {}", sender_id, e);
                     }
                 }
             } else {
-                debug!("Warning: No connection to node {}, skipping broadcast", node.id());
+                debug!("Warning: No connection for sender_id {}, skipping broadcast", sender_id);
             }
         }
 
-        // Ensure self-delivery via loopback
-        if !included_self {
+        // If no parties found, try legacy loopback as fallback
+        if party_count == 0 {
             if let Some(connection_ref) = self.connections.get(&self.node_id) {
                 let connection = connection_ref.value();
                 if connection.is_connected().await && connection.send(message).await.is_ok() {
-                    debug!("Successfully broadcasted message to self (loopback)");
+                    debug!("Successfully broadcasted message to self (loopback fallback)");
                     total_bytes += message.len();
                 }
             }
@@ -1275,9 +1558,77 @@ impl Network for QuicNetworkManager {
 }
 
 // ============================================================================
-// CERTIFICATE VERIFIER (Development Only)
+// CERTIFICATE VERIFIERS (Development Only)
 // ============================================================================
 
+/// Client certificate verifier that accepts all client certificates without verification.
+/// DEVELOPMENT ONLY - do not use in production.
+#[derive(Debug)]
+struct SkipClientVerification;
+
+impl SkipClientVerification {
+    fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+}
+
+impl rustls::server::danger::ClientCertVerifier for SkipClientVerification {
+    fn root_hint_subjects(&self) -> &[rustls::DistinguishedName] {
+        &[]
+    }
+
+    fn verify_client_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::server::danger::ClientCertVerified, rustls::Error> {
+        // Accept all client certificates without verification
+        Ok(rustls::server::danger::ClientCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        // Client certificates are optional - clients without certs can still connect
+        false
+    }
+}
+
+/// Server certificate verifier that accepts all server certificates without verification.
+/// DEVELOPMENT ONLY - do not use in production.
 #[derive(Debug)]
 struct SkipServerVerification;
 
@@ -1331,5 +1682,796 @@ impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
         rustls::crypto::ring::default_provider()
             .signature_verification_algorithms
             .supported_schemes()
+    }
+}
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transports::net_envelope::NetEnvelope;
+
+    // Helper function to ensure crypto provider is installed
+    fn ensure_crypto_provider() {
+        // Install the default crypto provider (ring) if not already installed
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    // ========================================================================
+    // ALPN Constants Tests
+    // ========================================================================
+
+    #[test]
+    fn test_alpn_constants_are_distinct() {
+        assert_ne!(ALPN_CLIENT_PROTOCOL, ALPN_SERVER_PROTOCOL);
+        assert_eq!(ALPN_CLIENT_PROTOCOL, b"client-protocol");
+        assert_eq!(ALPN_SERVER_PROTOCOL, b"server-protocol");
+    }
+
+    // ========================================================================
+    // Certificate and Public Key Tests
+    // ========================================================================
+
+    #[test]
+    fn test_certificate_generation_and_public_key_extraction() {
+        // Generate a self-signed certificate
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])
+            .expect("Failed to generate certificate");
+
+        let cert_der = cert.cert.der().to_vec();
+
+        // Extract public key
+        let public_key = QuicNetworkManager::extract_public_key_from_cert(&cert_der)
+            .expect("Failed to extract public key");
+
+        // Public key should not be empty
+        assert!(!public_key.0.is_empty());
+
+        // Public key should be valid DER-encoded SPKI (starts with SEQUENCE tag 0x30)
+        assert_eq!(public_key.0[0], 0x30, "Public key should start with SEQUENCE tag");
+    }
+
+    #[test]
+    fn test_different_certificates_have_different_public_keys() {
+        let cert1 = rcgen::generate_simple_self_signed(vec!["localhost".into()])
+            .expect("Failed to generate certificate 1");
+        let cert2 = rcgen::generate_simple_self_signed(vec!["localhost".into()])
+            .expect("Failed to generate certificate 2");
+
+        let pk1 = QuicNetworkManager::extract_public_key_from_cert(cert1.cert.der())
+            .expect("Failed to extract pk1");
+        let pk2 = QuicNetworkManager::extract_public_key_from_cert(cert2.cert.der())
+            .expect("Failed to extract pk2");
+
+        // Different certificates should have different public keys
+        assert_ne!(pk1, pk2);
+    }
+
+    #[test]
+    fn test_same_certificate_same_public_key() {
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])
+            .expect("Failed to generate certificate");
+
+        let pk1 = QuicNetworkManager::extract_public_key_from_cert(cert.cert.der())
+            .expect("Failed to extract pk1");
+        let pk2 = QuicNetworkManager::extract_public_key_from_cert(cert.cert.der())
+            .expect("Failed to extract pk2");
+
+        // Same certificate should yield same public key
+        assert_eq!(pk1, pk2);
+    }
+
+    #[test]
+    fn test_ensure_local_certificate() {
+        let mut manager = QuicNetworkManager::new();
+
+        // Initially no certificate
+        assert!(manager.local_cert_der.is_none());
+        assert!(manager.local_key_der.is_none());
+        assert!(manager.local_public_key.is_none());
+
+        // Ensure certificate is created
+        manager.ensure_local_certificate().expect("Failed to ensure certificate");
+
+        // Now should have certificate
+        assert!(manager.local_cert_der.is_some());
+        assert!(manager.local_key_der.is_some());
+        assert!(manager.local_public_key.is_some());
+
+        // Store references for comparison
+        let cert_der = manager.local_cert_der.clone();
+        let public_key = manager.local_public_key.clone();
+
+        // Calling again should not change the certificate
+        manager.ensure_local_certificate().expect("Failed on second call");
+
+        assert_eq!(manager.local_cert_der, cert_der);
+        assert_eq!(manager.local_public_key, public_key);
+    }
+
+    // ========================================================================
+    // NodePublicKey Tests
+    // ========================================================================
+
+    #[test]
+    fn test_node_public_key_ordering() {
+        let pk1 = NodePublicKey(vec![0x00, 0x01, 0x02]);
+        let pk2 = NodePublicKey(vec![0x00, 0x01, 0x03]);
+        let pk3 = NodePublicKey(vec![0x00, 0x02, 0x01]);
+
+        // Test ordering
+        assert!(pk1 < pk2);
+        assert!(pk2 < pk3);
+        assert!(pk1 < pk3);
+    }
+
+    #[test]
+    fn test_node_public_key_equality() {
+        let pk1 = NodePublicKey(vec![0x00, 0x01, 0x02]);
+        let pk2 = NodePublicKey(vec![0x00, 0x01, 0x02]);
+        let pk3 = NodePublicKey(vec![0x00, 0x01, 0x03]);
+
+        assert_eq!(pk1, pk2);
+        assert_ne!(pk1, pk3);
+    }
+
+    #[test]
+    fn test_node_public_key_clone() {
+        let pk1 = NodePublicKey(vec![0x00, 0x01, 0x02]);
+        let pk2 = pk1.clone();
+
+        assert_eq!(pk1, pk2);
+    }
+
+    // ========================================================================
+    // sender_id Computation Tests
+    // ========================================================================
+
+    #[test]
+    fn test_compute_sender_id_no_local_key() {
+        let manager = QuicNetworkManager::new();
+
+        // Without local public key, compute_sender_id should return None
+        assert!(manager.compute_sender_id().is_none());
+    }
+
+    #[test]
+    fn test_compute_sender_id_single_node() {
+        let mut manager = QuicNetworkManager::new();
+        manager.ensure_local_certificate().expect("Failed to ensure certificate");
+
+        // With only local node, sender_id should be 0
+        let sender_id = manager.compute_sender_id();
+        assert_eq!(sender_id, Some(0));
+    }
+
+    #[test]
+    fn test_compute_sender_id_multiple_nodes() {
+        let mut manager = QuicNetworkManager::new();
+        manager.ensure_local_certificate().expect("Failed to ensure certificate");
+
+        let local_pk = manager.local_public_key.clone().unwrap();
+
+        // Add peer public keys that are lexicographically before and after local
+        let pk_before = NodePublicKey(vec![0x00]); // Likely before any real key
+        let pk_after = NodePublicKey(vec![0xFF; 1000]); // Likely after any real key
+
+        manager.peer_public_keys.insert(1, pk_before);
+        manager.peer_public_keys.insert(2, pk_after);
+
+        // Compute sender_id
+        let sender_id = manager.compute_sender_id().expect("Should compute sender_id");
+
+        // Local key should be in the middle (position 1)
+        // Since pk_before < local_pk < pk_after when sorted
+        assert_eq!(sender_id, 1);
+    }
+
+    #[test]
+    fn test_compute_sender_id_deterministic_ordering() {
+        // Create three managers and ensure they compute consistent sender_ids
+        let mut manager1 = QuicNetworkManager::new();
+        let mut manager2 = QuicNetworkManager::new();
+        let mut manager3 = QuicNetworkManager::new();
+
+        manager1.ensure_local_certificate().unwrap();
+        manager2.ensure_local_certificate().unwrap();
+        manager3.ensure_local_certificate().unwrap();
+
+        let pk1 = manager1.local_public_key.clone().unwrap();
+        let pk2 = manager2.local_public_key.clone().unwrap();
+        let pk3 = manager3.local_public_key.clone().unwrap();
+
+        // Simulate full connectivity - each manager knows about others
+        manager1.peer_public_keys.insert(2, pk2.clone());
+        manager1.peer_public_keys.insert(3, pk3.clone());
+
+        manager2.peer_public_keys.insert(1, pk1.clone());
+        manager2.peer_public_keys.insert(3, pk3.clone());
+
+        manager3.peer_public_keys.insert(1, pk1.clone());
+        manager3.peer_public_keys.insert(2, pk2.clone());
+
+        // Compute sender_ids
+        let id1 = manager1.compute_sender_id().unwrap();
+        let id2 = manager2.compute_sender_id().unwrap();
+        let id3 = manager3.compute_sender_id().unwrap();
+
+        // All sender_ids should be distinct and in range [0, 2]
+        let mut ids = vec![id1, id2, id3];
+        ids.sort();
+        assert_eq!(ids, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_sender_id_fallback() {
+        let manager = QuicNetworkManager::new();
+        let node_id = manager.node_id;
+
+        // Without local certificate, sender_id() should fallback to node_id
+        assert_eq!(manager.sender_id(), node_id);
+    }
+
+    #[test]
+    fn test_is_fully_connected() {
+        let mut manager = QuicNetworkManager::new();
+
+        // Not fully connected without local key
+        assert!(!manager.is_fully_connected(3));
+
+        manager.ensure_local_certificate().unwrap();
+
+        // With local key only, need 0 peers for count=1
+        assert!(manager.is_fully_connected(1));
+
+        // For count=3, need 2 peers
+        assert!(!manager.is_fully_connected(3));
+
+        manager.peer_public_keys.insert(1, NodePublicKey(vec![0x01]));
+        assert!(!manager.is_fully_connected(3)); // Still need 1 more
+
+        manager.peer_public_keys.insert(2, NodePublicKey(vec![0x02]));
+        assert!(manager.is_fully_connected(3)); // Now fully connected
+    }
+
+    #[test]
+    fn test_finalized_sender_id() {
+        let mut manager = QuicNetworkManager::new();
+        manager.ensure_local_certificate().unwrap();
+
+        // Not fully connected yet
+        assert!(manager.finalized_sender_id(3).is_none());
+
+        manager.peer_public_keys.insert(1, NodePublicKey(vec![0x01]));
+        manager.peer_public_keys.insert(2, NodePublicKey(vec![0x02]));
+
+        // Now fully connected
+        let finalized = manager.finalized_sender_id(3);
+        assert!(finalized.is_some());
+    }
+
+    // ========================================================================
+    // Client Config Tests
+    // ========================================================================
+
+    #[test]
+    fn test_create_client_config_for_client_role() {
+        ensure_crypto_provider();
+        let config = QuicNetworkManager::create_insecure_client_config(ClientType::Client, None, None);
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn test_create_client_config_for_server_role() {
+        ensure_crypto_provider();
+        let config = QuicNetworkManager::create_insecure_client_config(ClientType::Server, None, None);
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn test_create_client_config_with_certificate() {
+        ensure_crypto_provider();
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])
+            .expect("Failed to generate certificate");
+        let cert_der = cert.cert.der().to_vec();
+        let key_der = cert.signing_key.serialize_der();
+
+        let config = QuicNetworkManager::create_insecure_client_config(
+            ClientType::Client,
+            Some(&cert_der),
+            Some(&key_der),
+        );
+        assert!(config.is_ok());
+    }
+
+    // ========================================================================
+    // Server Config Tests
+    // ========================================================================
+
+    #[test]
+    fn test_create_server_config() {
+        ensure_crypto_provider();
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])
+            .expect("Failed to generate certificate");
+
+        let cert_der = cert.cert.der().to_vec();
+        let key_der = cert.signing_key.serialize_der();
+
+        let config = QuicNetworkManager::create_self_signed_server_config(&cert_der, &key_der);
+        assert!(config.is_ok());
+    }
+
+    // ========================================================================
+    // NetEnvelope Tests
+    // ========================================================================
+
+    #[test]
+    fn test_net_envelope_handshake_serialization() {
+        let envelope = NetEnvelope::Handshake { id: 42 };
+        let bytes = envelope.serialize();
+
+        let deserialized = NetEnvelope::try_deserialize(&bytes)
+            .expect("Failed to deserialize");
+
+        match deserialized {
+            NetEnvelope::Handshake { id } => assert_eq!(id, 42),
+            _ => panic!("Expected Handshake variant"),
+        }
+    }
+
+    #[test]
+    fn test_net_envelope_honeybadger_serialization() {
+        let data = vec![1, 2, 3, 4, 5];
+        let envelope = NetEnvelope::HoneyBadger(data.clone());
+        let bytes = envelope.serialize();
+
+        let deserialized = NetEnvelope::try_deserialize(&bytes)
+            .expect("Failed to deserialize");
+
+        match deserialized {
+            NetEnvelope::HoneyBadger(d) => assert_eq!(d, data),
+            _ => panic!("Expected HoneyBadger variant"),
+        }
+    }
+
+    // ========================================================================
+    // QuicNetworkManager Integration Tests
+    // ========================================================================
+
+    #[test]
+    fn test_manager_initialization() {
+        let manager = QuicNetworkManager::new();
+
+        assert!(manager.endpoint.is_none());
+        assert!(manager.nodes.is_empty());
+        assert!(manager.connections.is_empty());
+        assert!(manager.client_connections.is_empty());
+        assert!(manager.client_ids.is_empty());
+        assert!(manager.local_cert_der.is_none());
+        assert!(manager.local_key_der.is_none());
+        assert!(manager.local_public_key.is_none());
+        assert!(manager.peer_public_keys.is_empty());
+    }
+
+    #[test]
+    fn test_manager_with_node_id() {
+        let custom_id = 12345;
+        let manager = QuicNetworkManager::with_node_id(custom_id);
+
+        assert_eq!(manager.node_id, custom_id);
+        assert_eq!(manager.get_node_id(), custom_id);
+    }
+
+    #[test]
+    fn test_get_public_key() {
+        let mut manager = QuicNetworkManager::new();
+
+        // Initially no public key
+        assert!(manager.get_public_key().is_none());
+
+        manager.ensure_local_certificate().unwrap();
+
+        // Now should have public key
+        assert!(manager.get_public_key().is_some());
+    }
+
+    // ========================================================================
+    // Async Integration Tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_listen_creates_endpoint_and_certificate() {
+        ensure_crypto_provider();
+        let mut manager = QuicNetworkManager::new();
+
+        // Listen on a random port
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        manager.listen(addr).await.expect("Failed to listen");
+
+        // Should have endpoint now
+        assert!(manager.endpoint.is_some());
+
+        // Should have certificate
+        assert!(manager.local_cert_der.is_some());
+        assert!(manager.local_key_der.is_some());
+        assert!(manager.local_public_key.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_loopback_installed_after_listen() {
+        ensure_crypto_provider();
+        let mut manager = QuicNetworkManager::new();
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        manager.listen(addr).await.expect("Failed to listen");
+
+        // Loopback should be installed
+        assert!(manager.connections.contains_key(&manager.node_id));
+    }
+
+    #[tokio::test]
+    async fn test_server_to_server_connection() {
+        ensure_crypto_provider();
+        // Create two managers
+        let mut server1 = QuicNetworkManager::with_node_id(1);
+        let mut server2 = QuicNetworkManager::with_node_id(2);
+
+        // Start listening on server1
+        let addr1: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        server1.listen(addr1).await.expect("Failed to start server1");
+
+        // Get actual bound address
+        let bound_addr = server1.endpoint.as_ref().unwrap().local_addr().unwrap();
+
+        // Server2 connects to server1 as a server (ID is derived from public key)
+        let conn_task = tokio::spawn(async move {
+            let result = server2.connect_as_server(bound_addr).await;
+            (server2, result)
+        });
+
+        // Server1 accepts the connection
+        let accept_result = server1.accept().await;
+
+        // Wait for connection task
+        let (server2, connect_result) = conn_task.await.unwrap();
+
+        // Both should succeed
+        assert!(accept_result.is_ok(), "Accept failed: {:?}", accept_result.err());
+        assert!(connect_result.is_ok(), "Connect failed: {:?}", connect_result.err());
+
+        // Check that connections were stored with derived IDs
+        // Server1 should have a connection to server2 (by server2's derived ID)
+        let server2_derived_id = server2.local_derived_id();
+        assert!(server1.connections.contains_key(&server2_derived_id),
+            "server1 should have connection to server2 with derived ID {}", server2_derived_id);
+    }
+
+    #[tokio::test]
+    async fn test_client_to_server_connection() {
+        ensure_crypto_provider();
+        // Create server and client managers
+        let mut server = QuicNetworkManager::with_node_id(1);
+        let mut client = QuicNetworkManager::with_node_id(100);
+
+        // Start listening on server
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        server.listen(addr).await.expect("Failed to start server");
+
+        let bound_addr = server.endpoint.as_ref().unwrap().local_addr().unwrap();
+
+        // Client connects to server (ID is derived from public key)
+        let conn_task = tokio::spawn(async move {
+            let result = client.connect_as_client(bound_addr).await;
+            (client, result)
+        });
+
+        // Server accepts the connection
+        let accept_result = server.accept().await;
+
+        // Wait for connection task
+        let (client, connect_result) = conn_task.await.unwrap();
+
+        // Both should succeed
+        assert!(accept_result.is_ok(), "Accept failed: {:?}", accept_result.err());
+        assert!(connect_result.is_ok(), "Connect failed: {:?}", connect_result.err());
+
+        // Check that server stored client connection with derived ID
+        let client_derived_id = client.local_derived_id();
+        assert!(server.client_connections.contains_key(&client_derived_id),
+            "server should have client connection with derived ID {}", client_derived_id);
+        assert!(server.client_ids.contains(&client_derived_id));
+    }
+
+    #[tokio::test]
+    async fn test_connection_role_from_alpn() {
+        ensure_crypto_provider();
+        let mut server = QuicNetworkManager::with_node_id(1);
+        let mut client = QuicNetworkManager::with_node_id(100);
+
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        server.listen(addr).await.expect("Failed to start server");
+
+        let bound_addr = server.endpoint.as_ref().unwrap().local_addr().unwrap();
+
+        let conn_task = tokio::spawn(async move {
+            client.connect_as_client(bound_addr).await
+        });
+
+        let accept_result = server.accept().await.expect("Accept failed");
+        let _connect_result = conn_task.await.unwrap().expect("Connect failed");
+
+        // Server should see the connection as coming from a Client
+        assert_eq!(accept_result.get_connection_role(), ClientType::Client);
+    }
+
+    #[tokio::test]
+    async fn test_public_keys_exchanged_on_server_connection() {
+        ensure_crypto_provider();
+        let mut server1 = QuicNetworkManager::with_node_id(1);
+        let mut server2 = QuicNetworkManager::with_node_id(2);
+
+        // Both servers need to have their certificates generated
+        let addr1: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let addr2: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        server1.listen(addr1).await.expect("Failed to start server1");
+        server2.listen(addr2).await.expect("Failed to start server2");
+
+        let bound_addr = server1.endpoint.as_ref().unwrap().local_addr().unwrap();
+
+        let conn_task = tokio::spawn(async move {
+            server2.connect_as_server(bound_addr).await.expect("Connect failed");
+            server2
+        });
+
+        let _accept_result = server1.accept().await.expect("Accept failed");
+        let server2 = conn_task.await.unwrap();
+
+        // Both servers should have their own local public keys
+        assert!(server1.local_public_key.is_some());
+        assert!(server2.local_public_key.is_some());
+
+        // With mTLS, server1 should have server2's public key stored
+        let server2_derived_id = server2.local_derived_id();
+        assert!(server1.peer_public_keys.contains_key(&server2_derived_id),
+            "server1 should have server2's public key stored");
+    }
+
+    #[tokio::test]
+    async fn test_send_receive_after_connection() {
+        ensure_crypto_provider();
+        let mut server = QuicNetworkManager::with_node_id(1);
+        let mut client = QuicNetworkManager::with_node_id(100);
+
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        server.listen(addr).await.expect("Failed to start server");
+
+        let bound_addr = server.endpoint.as_ref().unwrap().local_addr().unwrap();
+
+        let conn_task = tokio::spawn(async move {
+            let conn = client.connect_as_client(bound_addr).await.expect("Connect failed");
+            (client, conn)
+        });
+
+        let server_conn = server.accept().await.expect("Accept failed");
+        let (_client, client_conn) = conn_task.await.unwrap();
+
+        // Test sending from client to server
+        let test_data = b"Hello, server!";
+        client_conn.send(test_data).await.expect("Send failed");
+
+        let received = server_conn.receive().await.expect("Receive failed");
+        assert_eq!(received, test_data);
+
+        // Test sending from server to client
+        let response_data = b"Hello, client!";
+        server_conn.send(response_data).await.expect("Send response failed");
+
+        let received_response = client_conn.receive().await.expect("Receive response failed");
+        assert_eq!(received_response, response_data);
+    }
+
+    #[tokio::test]
+    async fn test_local_derived_id() {
+        ensure_crypto_provider();
+        let mut manager = QuicNetworkManager::new();
+
+        // Before certificate generation, local_derived_id should return node_id
+        let initial_id = manager.local_derived_id();
+        assert_eq!(initial_id, manager.node_id);
+
+        // After certificate generation
+        manager.ensure_local_certificate().unwrap();
+
+        // Now local_derived_id should return derived ID from public key
+        let derived_id = manager.local_derived_id();
+        let expected_id = manager.local_public_key.as_ref().unwrap().derive_id();
+        assert_eq!(derived_id, expected_id);
+    }
+
+    #[test]
+    fn test_node_public_key_derive_id() {
+        let pk1 = NodePublicKey(vec![0x00, 0x01, 0x02]);
+        let pk2 = NodePublicKey(vec![0x00, 0x01, 0x02]);
+        let pk3 = NodePublicKey(vec![0x00, 0x01, 0x03]);
+
+        // Same public key should derive same ID
+        assert_eq!(pk1.derive_id(), pk2.derive_id());
+
+        // Different public keys should derive different IDs
+        assert_ne!(pk1.derive_id(), pk3.derive_id());
+    }
+
+    #[test]
+    fn test_node_public_key_derive_id_deterministic() {
+        let pk = NodePublicKey(vec![0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01]);
+
+        // Multiple calls should return the same ID
+        let id1 = pk.derive_id();
+        let id2 = pk.derive_id();
+        let id3 = pk.derive_id();
+
+        assert_eq!(id1, id2);
+        assert_eq!(id2, id3);
+    }
+
+    #[test]
+    fn test_get_sorted_public_keys() {
+        ensure_crypto_provider();
+        let mut manager = QuicNetworkManager::new();
+        manager.ensure_local_certificate().unwrap();
+
+        // Create some peer public keys (manually sorted in reverse to test sorting)
+        let pk_c = NodePublicKey(vec![0x03, 0x01, 0x02]);
+        let pk_b = NodePublicKey(vec![0x02, 0x01, 0x02]);
+        let pk_a = NodePublicKey(vec![0x01, 0x01, 0x02]);
+
+        manager.peer_public_keys.insert(pk_c.derive_id(), pk_c.clone());
+        manager.peer_public_keys.insert(pk_b.derive_id(), pk_b.clone());
+        manager.peer_public_keys.insert(pk_a.derive_id(), pk_a.clone());
+
+        let sorted = manager.get_sorted_public_keys();
+
+        // Should have 4 keys (local + 3 peers)
+        assert_eq!(sorted.len(), 4);
+
+        // Keys should be sorted lexicographically
+        for i in 1..sorted.len() {
+            assert!(sorted[i - 1].0 < sorted[i].0, "Keys should be sorted");
+        }
+    }
+
+    #[test]
+    fn test_get_public_key_for_sender_id() {
+        ensure_crypto_provider();
+        let mut manager = QuicNetworkManager::new();
+        manager.ensure_local_certificate().unwrap();
+
+        // Add a peer with a known public key
+        let peer_pk = NodePublicKey(vec![0xFF, 0xFF, 0xFF]); // Will sort after local key
+        manager.peer_public_keys.insert(peer_pk.derive_id(), peer_pk.clone());
+
+        // Get the sorted keys to determine expected order
+        let sorted = manager.get_sorted_public_keys();
+        assert_eq!(sorted.len(), 2);
+
+        // sender_id 0 should be the first in sorted order
+        let pk0 = manager.get_public_key_for_sender_id(0).unwrap();
+        assert_eq!(pk0, sorted[0]);
+
+        // sender_id 1 should be the second in sorted order
+        let pk1 = manager.get_public_key_for_sender_id(1).unwrap();
+        assert_eq!(pk1, sorted[1]);
+
+        // sender_id 2 should be None (out of range)
+        assert!(manager.get_public_key_for_sender_id(2).is_none());
+    }
+
+    #[test]
+    fn test_get_sender_id_for_public_key() {
+        ensure_crypto_provider();
+        let mut manager = QuicNetworkManager::new();
+        manager.ensure_local_certificate().unwrap();
+
+        let local_pk = manager.local_public_key.clone().unwrap();
+
+        // Add peers with known public keys
+        let peer_pk1 = NodePublicKey(vec![0x00, 0x00, 0x01]);
+        let peer_pk2 = NodePublicKey(vec![0xFF, 0xFF, 0xFF]);
+        manager.peer_public_keys.insert(peer_pk1.derive_id(), peer_pk1.clone());
+        manager.peer_public_keys.insert(peer_pk2.derive_id(), peer_pk2.clone());
+
+        // Get sorted keys
+        let sorted = manager.get_sorted_public_keys();
+        assert_eq!(sorted.len(), 3);
+
+        // Each key should map to its position in the sorted list
+        for (expected_id, pk) in sorted.iter().enumerate() {
+            let actual_id = manager.get_sender_id_for_public_key(pk).unwrap();
+            assert_eq!(actual_id, expected_id, "sender_id should match position in sorted list");
+        }
+
+        // Unknown public key should return None
+        let unknown_pk = NodePublicKey(vec![0xAA, 0xBB, 0xCC]);
+        assert!(manager.get_sender_id_for_public_key(&unknown_pk).is_none());
+    }
+
+    #[test]
+    fn test_party_count() {
+        ensure_crypto_provider();
+        let mut manager = QuicNetworkManager::new();
+
+        // Initially no parties (no certificate)
+        assert_eq!(manager.party_count(), 0);
+
+        // After generating certificate, we have 1 party (self)
+        manager.ensure_local_certificate().unwrap();
+        assert_eq!(manager.party_count(), 1);
+
+        // Add peers
+        let pk1 = NodePublicKey(vec![0x01]);
+        let pk2 = NodePublicKey(vec![0x02]);
+        manager.peer_public_keys.insert(pk1.derive_id(), pk1);
+        assert_eq!(manager.party_count(), 2);
+
+        manager.peer_public_keys.insert(pk2.derive_id(), pk2);
+        assert_eq!(manager.party_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_sender_ids_are_sequential_0_to_n() {
+        ensure_crypto_provider();
+
+        // Create two servers
+        let mut server1 = QuicNetworkManager::with_node_id(1);
+        let mut server2 = QuicNetworkManager::with_node_id(2);
+
+        // Start listening (generates certificates)
+        let addr1: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let addr2: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        server1.listen(addr1).await.expect("Failed to start server1");
+        server2.listen(addr2).await.expect("Failed to start server2");
+
+        let bound_addr = server1.endpoint.as_ref().unwrap().local_addr().unwrap();
+
+        // Connect server2 to server1
+        let conn_task = tokio::spawn(async move {
+            server2.connect_as_server(bound_addr).await.expect("Connect failed");
+            server2
+        });
+
+        let _accept = server1.accept().await.expect("Accept failed");
+        let server2 = conn_task.await.unwrap();
+
+        // Both should now have 2 parties
+        assert_eq!(server1.party_count(), 2);
+        assert_eq!(server2.party_count(), 2);
+
+        // Sender IDs should be 0 and 1
+        let server1_sender_id = server1.compute_sender_id().unwrap();
+        let server2_sender_id = server2.compute_sender_id().unwrap();
+
+        // One should be 0, the other should be 1
+        assert!(server1_sender_id == 0 || server1_sender_id == 1);
+        assert!(server2_sender_id == 0 || server2_sender_id == 1);
+        assert_ne!(server1_sender_id, server2_sender_id, "Sender IDs should be different");
+
+        // Verify the IDs are consistent across both servers
+        // Both servers should agree on who is 0 and who is 1
+        let server1_pk = server1.local_public_key.clone().unwrap();
+        let server2_pk = server2.local_public_key.clone().unwrap();
+
+        // From server1's perspective
+        let s1_id_for_s1 = server1.get_sender_id_for_public_key(&server1_pk).unwrap();
+        let s1_id_for_s2 = server1.get_sender_id_for_public_key(&server2_pk).unwrap();
+
+        // From server2's perspective
+        let s2_id_for_s1 = server2.get_sender_id_for_public_key(&server1_pk).unwrap();
+        let s2_id_for_s2 = server2.get_sender_id_for_public_key(&server2_pk).unwrap();
+
+        // Both should agree on sender IDs
+        assert_eq!(s1_id_for_s1, s2_id_for_s1, "Both servers should agree on server1's sender_id");
+        assert_eq!(s1_id_for_s2, s2_id_for_s2, "Both servers should agree on server2's sender_id");
     }
 }


### PR DESCRIPTION
Networking now orders the public keys and we can get the sender id from this.