### PR TITLE
PoC: consensus gate can block forever with partial expected counts

### DIFF
--- a/src/transports/quic.rs
+++ b/src/transports/quic.rs
@@ -4823,6 +4823,44 @@ mod tests {
         manager.maybe_start_consensus();
     }
 
+    /// PoC validation for review finding:
+    /// With only one expected threshold configured, gate is Pending but
+    /// maybe_start_consensus() exits early and sends remain blocked.
+    #[tokio::test]
+    async fn test_poc_consensus_gate_stuck_with_only_expected_parties() {
+        ensure_crypto_provider();
+
+        let config = QuicNetworkConfig {
+            expected_parties: Some(1),
+            expected_clients: None,
+            ..Default::default()
+        };
+        let mut manager = QuicNetworkManager::with_config(config);
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        manager.listen(addr).await.expect("listen failed");
+
+        assert_eq!(*manager.consensus_gate_rx.borrow(), ConsensusGate::Pending);
+
+        manager.maybe_start_consensus();
+
+        let gate_result = tokio::time::timeout(
+            Duration::from_millis(200),
+            manager.await_consensus_gate(),
+        )
+        .await;
+
+        assert!(
+            gate_result.is_ok(),
+            "consensus gate stayed blocked when expected_parties threshold was already met"
+        );
+        assert!(
+            manager
+                .consensus_started
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "consensus should start when one configured threshold is met"
+        );
+    }
+
     #[tokio::test]
     async fn test_sorted_client_keys_deterministic() {
         ensure_crypto_provider();


### PR DESCRIPTION
## Summary
Adds a failing regression test that reproduces the consensus gate deadlock when only one expected threshold is configured.

## PoC test
- `test_poc_consensus_gate_stuck_with_only_expected_parties`

## Repro
`cargo test test_poc_consensus_gate_stuck_with_only_expected_parties -- --nocapture`

## Observed failure
The test times out on `await_consensus_gate()` and panics with:
`consensus gate stayed blocked when expected_parties threshold was already met`.

## Why this validates the review finding
`with_config` marks the gate `Pending` when either threshold is set, but `maybe_start_consensus` returns unless both `expected_parties` and `expected_clients` are set, leaving sends blocked indefinitely in valid single-threshold configs.

PoC-only PR: no production fix included.
