### PR TITLE
Verify node-list agreement in consensus (include node digest in ClientListDigest)

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -20,6 +20,8 @@
 //! - Callbacks may be invoked from any thread in the tokio runtime thread pool
 //! - Thread-local error storage is used for error messages
 
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
 use std::cell::RefCell;
 use std::ffi::{c_char, c_void, CStr, CString};
 use std::net::SocketAddr;
@@ -29,8 +31,6 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 use tokio::task::AbortHandle;
-
-use rustls::crypto::CryptoProvider;
 
 use crate::network_utils::{Network, Node, PartyId, VerifiedOrdering};
 use crate::transports::quic::{ConnectionState, PeerConnection, QuicNetworkManager, QuicNode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,9 @@ pub trait PeerConnection: Send + Sync {
     fn close<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>>;
 }
 
+pub type BoxPeerConnectionFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Box<dyn PeerConnection>, String>> + Send + 'a>>;
+
 /// Manages network connections.
 ///
 /// This trait defines the interface for managing network connections.
@@ -260,7 +263,7 @@ pub trait NetworkManager: Send + Sync {
     fn connect<'a>(
         &'a mut self,
         address: SocketAddr,
-    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn PeerConnection>, String>> + Send + 'a>>;
+    ) -> BoxPeerConnectionFuture<'a>;
 
     /// Accepts an incoming connection.
     ///
@@ -277,9 +280,7 @@ pub trait NetworkManager: Send + Sync {
     /// - The endpoint is closed
     /// - TLS handshake with the connecting peer fails
     /// - Stream initialization fails
-    fn accept<'a>(
-        &'a mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Box<dyn PeerConnection>, String>> + Send + 'a>>;
+    fn accept<'a>(&'a mut self) -> BoxPeerConnectionFuture<'a>;
 
     /// Listens for incoming connections.
     ///

--- a/src/transports/ice.rs
+++ b/src/transports/ice.rs
@@ -284,7 +284,7 @@ impl CandidatePair {
         }
 
         // Sort by priority (highest first)
-        pairs.sort_by(|a, b| b.priority.cmp(&a.priority));
+        pairs.sort_by_key(|pair| std::cmp::Reverse(pair.priority));
 
         // Prune redundant pairs (same foundation pair)
         pairs.dedup_by(|a, b| {
@@ -319,11 +319,11 @@ impl LocalCandidates {
     /// Generates a random ICE credential of specified minimum length
     fn generate_credential(min_len: usize) -> String {
         const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/";
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         (0..min_len)
             .map(|_| {
-                let idx = rng.gen_range(0..CHARSET.len());
+                let idx = rng.random_range(0..CHARSET.len());
                 CHARSET[idx] as char
             })
             .collect()

--- a/src/transports/ice_agent.rs
+++ b/src/transports/ice_agent.rs
@@ -7,7 +7,6 @@ use crate::network_utils::PartyId;
 use crate::transports::ice::{CandidatePair, CandidatePairState, IceCandidate, LocalCandidates};
 use crate::transports::net_envelope::NetEnvelope;
 use crate::transports::stun::StunClient;
-use dashmap::DashMap;
 use quinn::Endpoint;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -235,14 +234,6 @@ pub struct CheckResult {
     pub peer_reflexive: Option<IceCandidate>,
 }
 
-/// Pending connectivity check tracking
-#[derive(Debug)]
-struct PendingCheck {
-    pair_index: usize,
-    sent_at: Instant,
-    retries: u32,
-}
-
 /// ICE Agent errors.
 ///
 /// These errors are returned by [`IceAgent`] methods when ICE operations fail.
@@ -314,8 +305,6 @@ pub struct IceAgent {
     nominated_pair: Option<usize>,
     /// Transaction ID counter
     transaction_counter: u64,
-    /// Pending transactions
-    pending_transactions: DashMap<u64, PendingCheck>,
     /// Start time for timeout tracking
     start_time: Option<Instant>,
     /// STUN client for gathering
@@ -399,7 +388,6 @@ impl IceAgent {
             check_list: Vec::new(),
             nominated_pair: None,
             transaction_counter: 0,
-            pending_transactions: DashMap::new(),
             start_time: None,
             stun_client: StunClient::new(stun_servers),
         })
@@ -428,7 +416,6 @@ impl IceAgent {
             check_list: Vec::new(),
             nominated_pair: None,
             transaction_counter: 0,
-            pending_transactions: DashMap::new(),
             start_time: None,
             stun_client: StunClient::new(stun_servers),
         }
@@ -483,7 +470,7 @@ impl IceAgent {
     ///
     /// This makes it easy to verify that a STUN response corresponds to our request
     /// by checking if the upper bits match our party ID.
-    fn next_transaction_id(&mut self) -> u64 {
+    pub fn next_transaction_id(&mut self) -> u64 {
         self.transaction_counter += 1;
         ((self.local_party_id as u64) << 32) | (self.transaction_counter & 0xFFFFFFFF)
     }
@@ -985,9 +972,9 @@ impl HolePunchCoordinator {
         role: IceRole,
         config: HolePunchConfig,
     ) -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         Self {
-            transaction_id: rng.r#gen(),
+            transaction_id: rng.random(),
             local_addr,
             remote_addr,
             role,
@@ -1075,7 +1062,7 @@ impl HolePunchCoordinator {
             .as_millis() as u64;
 
         let delay_ms = self.config.initial_delay.as_millis() as u64
-            + rand::thread_rng().gen_range(0..self.config.jitter_range.as_millis() as u64);
+            + rand::rng().random_range(0..self.config.jitter_range.as_millis() as u64);
 
         if self.role == IceRole::Controlling {
             // Send punch request with timing info
@@ -1087,7 +1074,7 @@ impl HolePunchCoordinator {
 
             signaling_send(request)
                 .await
-                .map_err(|e| HolePunchError::SignalingError(e))?;
+                .map_err(HolePunchError::SignalingError)?;
 
             // Wait for ack
             let ack_timeout = Duration::from_secs(5);
@@ -1133,7 +1120,7 @@ impl HolePunchCoordinator {
                 };
                 signaling_send(ack)
                     .await
-                    .map_err(|e| HolePunchError::SignalingError(e))?;
+                    .map_err(HolePunchError::SignalingError)?;
             }
         }
 
@@ -1189,9 +1176,8 @@ impl HolePunchCoordinator {
         })
         .await;
 
-        match accept_result {
-            Ok(Ok(conn)) => return Ok(conn),
-            _ => {}
+        if let Ok(Ok(conn)) = accept_result {
+            return Ok(conn);
         }
 
         // If accept didn't work, try connecting
@@ -2199,7 +2185,7 @@ mod integration_tests {
         let mut agent = IceAgent::new_unchecked(config, 1);
 
         let public_addr: SocketAddr = "203.0.113.5:5000".parse().unwrap();
-        let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let _socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
 
         // Manually set local candidates to a public IP to simulate production
         agent.local_candidates = LocalCandidates {

--- a/src/transports/net_envelope.rs
+++ b/src/transports/net_envelope.rs
@@ -145,12 +145,16 @@ pub enum NetEnvelope {
         node_keys: Vec<Vec<u8>>,
     },
 
-    /// Node-to-node: BLAKE3 digest of sorted client public key list.
+    /// Node-to-node: digests for sorted client and node public key lists.
     ClientListDigest {
-        /// 32-byte BLAKE3 digest
+        /// 32-byte BLAKE3 digest of sorted client keys
         digest: Vec<u8>,
-        /// Number of clients included in the digest
+        /// Number of clients included in the client digest
         client_count: usize,
+        /// 32-byte BLAKE3 digest of sorted node keys
+        node_digest: Vec<u8>,
+        /// Number of nodes included in the node digest
+        node_count: usize,
     },
 
     /// Node-to-node: full sorted client key list (diagnostic fallback).
@@ -409,16 +413,22 @@ mod tests {
         let envelope = NetEnvelope::ClientListDigest {
             digest: digest.clone(),
             client_count: 5,
+            node_digest: vec![0xCD; 32],
+            node_count: 3,
         };
         let bytes = envelope.serialize();
         let deserialized = NetEnvelope::try_deserialize(&bytes).unwrap();
         if let NetEnvelope::ClientListDigest {
             digest: d,
             client_count,
+            node_digest,
+            node_count,
         } = deserialized
         {
             assert_eq!(d, digest);
             assert_eq!(client_count, 5);
+            assert_eq!(node_digest, vec![0xCD; 32]);
+            assert_eq!(node_count, 3);
         } else {
             panic!("expected ClientListDigest variant");
         }
@@ -673,6 +683,8 @@ mod tests {
             NetEnvelope::ClientListDigest {
                 digest: vec![0xAB; 32],
                 client_count: 2,
+                node_digest: vec![0xBC; 32],
+                node_count: 2,
             },
             NetEnvelope::ClientListFull {
                 client_keys: vec![vec![1, 2]],

--- a/src/transports/quic.rs
+++ b/src/transports/quic.rs
@@ -159,6 +159,9 @@ impl Debug for dyn PeerConnection {
     }
 }
 
+type SharedPeerConnectionFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Arc<dyn PeerConnection>, String>> + Send + 'a>>;
+
 // ============================================================================
 // NETWORK MANAGER TRAIT
 // ============================================================================
@@ -167,11 +170,9 @@ pub trait NetworkManager: Send + Sync {
     fn connect<'a>(
         &'a mut self,
         address: SocketAddr,
-    ) -> Pin<Box<dyn Future<Output = Result<Arc<dyn PeerConnection>, String>> + Send + 'a>>;
+    ) -> SharedPeerConnectionFuture<'a>;
 
-    fn accept<'a>(
-        &'a mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Arc<dyn PeerConnection>, String>> + Send + 'a>>;
+    fn accept<'a>(&'a mut self) -> SharedPeerConnectionFuture<'a>;
 
     fn listen<'a>(
         &'a mut self,
@@ -438,7 +439,7 @@ impl PeerConnection for QuicPeerConnection {
             }
 
             let mut send_guard = self.send_stream.lock().await;
-            match send_framed_message(&mut *send_guard, data).await {
+            match send_framed_message(&mut send_guard, data).await {
                 Ok(()) => Ok(()),
                 Err(ConnectionError::ConnectionLost(msg)) => {
                     self.update_state(ConnectionState::Disconnected).await;
@@ -467,7 +468,7 @@ impl PeerConnection for QuicPeerConnection {
             }
 
             let mut recv_guard = self.recv_stream.lock().await;
-            match recv_framed_message(&mut *recv_guard).await {
+            match recv_framed_message(&mut recv_guard).await {
                 Ok(data) => Ok(data),
                 Err(ConnectionError::ConnectionLost(msg)) => {
                     self.update_state(ConnectionState::Disconnected).await;
@@ -750,7 +751,7 @@ fn extract_alpn_role(connection: &Connection) -> Result<ClientType, String> {
         .downcast::<quinn::crypto::rustls::HandshakeData>()
         .map_err(|_| "Failed to downcast handshake data to rustls type".to_string())?;
 
-    match handshake.protocol.as_ref().map(|v| v.as_slice()) {
+    match handshake.protocol.as_deref() {
         Some(proto) if proto == ALPN_CLIENT_PROTOCOL => {
             trace!("ALPN negotiated: client-protocol");
             Ok(ClientType::Client)
@@ -2792,13 +2793,11 @@ impl NetworkManager for QuicNetworkManager {
     fn connect<'a>(
         &'a mut self,
         address: SocketAddr,
-    ) -> Pin<Box<dyn Future<Output = Result<Arc<dyn PeerConnection>, String>> + Send + 'a>> {
+    ) -> SharedPeerConnectionFuture<'a> {
         Box::pin(async move { self.connect_as_server(address).await })
     }
 
-    fn accept<'a>(
-        &'a mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Arc<dyn PeerConnection>, String>> + Send + 'a>> {
+    fn accept<'a>(&'a mut self) -> SharedPeerConnectionFuture<'a> {
         Box::pin(async move {
             let endpoint = self
                 .endpoint
@@ -3300,7 +3299,6 @@ impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
 mod tests {
     use super::*;
     use crate::transports::net_envelope::NetEnvelope;
-    use rustls::client::danger::ServerCertVerifier;
     use rustls::server::danger::ClientCertVerifier;
 
     // Helper function to ensure crypto provider is installed
@@ -3542,8 +3540,6 @@ mod tests {
         manager
             .ensure_local_certificate()
             .expect("Failed to ensure certificate");
-
-        let local_pk = manager.local_public_key.clone().unwrap();
 
         // Add peer public keys that are lexicographically before and after local
         let pk_before = NodePublicKey(vec![0x00]); // Likely before any real key
@@ -4228,8 +4224,6 @@ mod tests {
         let mut manager = QuicNetworkManager::new();
         manager.ensure_local_certificate().unwrap();
 
-        let local_pk = manager.local_public_key.clone().unwrap();
-
         // Add peers with known public keys
         let peer_pk1 = NodePublicKey(vec![0x00, 0x00, 0x01]);
         let peer_pk2 = NodePublicKey(vec![0xFF, 0xFF, 0xFF]);
@@ -4536,10 +4530,12 @@ mod tests {
         // Initial Vec::with_capacity is capped at RECV_CHUNK_SIZE even for
         // larger declared payloads — memory only grows as data arrives.
         assert_eq!(RECV_CHUNK_SIZE, 64 * 1024);
-        assert!(
-            RECV_CHUNK_SIZE < MAX_MESSAGE_SIZE,
-            "Chunk size must be smaller than max message size"
-        );
+        const {
+            assert!(
+                RECV_CHUNK_SIZE < MAX_MESSAGE_SIZE,
+                "Chunk size must be smaller than max message size"
+            );
+        }
     }
 
     #[test]
@@ -5528,7 +5524,7 @@ mod tests {
         // Verify the snapshot-derived party_id matches compute_local_party_id
         assert_eq!(
             local_party_id,
-            manager.compute_local_party_id().map(|id| id),
+            manager.compute_local_party_id(),
             "snapshot-derived party_id must match compute_local_party_id"
         );
     }

--- a/src/transports/quic.rs
+++ b/src/transports/quic.rs
@@ -2492,6 +2492,14 @@ impl QuicNetworkManager {
         blake3::hash(&serialized).as_bytes().to_vec()
     }
 
+    /// Computes BLAKE3 digest of the sorted node public key list.
+    pub fn compute_node_list_digest(&self) -> Vec<u8> {
+        let sorted = self.get_sorted_public_keys();
+        let raw: Vec<Vec<u8>> = sorted.iter().map(|k| k.0.clone()).collect();
+        let serialized = bincode::serialize(&raw).expect("serialization should not fail");
+        blake3::hash(&serialized).as_bytes().to_vec()
+    }
+
     /// Checks if consensus should start and spawns the consensus task if so.
     /// Called from accept() and connect_as_server() after storing connections.
     fn maybe_start_consensus(&self) {
@@ -2564,6 +2572,7 @@ impl QuicNetworkManager {
             ))? as PartyId;
         let client_keys = self.get_sorted_client_keys();
         let local_digest = self.compute_client_list_digest();
+        let local_node_digest = self.compute_node_list_digest();
 
         debug!(
             "Executing consensus: party_id={}, party_count={}, client_count={}",
@@ -2576,6 +2585,8 @@ impl QuicNetworkManager {
         let digest_msg = NetEnvelope::ClientListDigest {
             digest: local_digest.clone(),
             client_count: client_keys.len(),
+            node_digest: local_node_digest.clone(),
+            node_count: node_keys.len(),
         };
         let digest_bytes = digest_msg.serialize();
         for pid in 0..party_count {
@@ -2600,15 +2611,20 @@ impl QuicNetworkManager {
                 tokio::spawn(async move {
                     match conn.receive().await {
                         Ok(data) => match NetEnvelope::try_deserialize(&data) {
-                            Ok(NetEnvelope::ClientListDigest { digest, .. }) => {
-                                let _ = tx.send((pid, digest)).await;
+                            Ok(NetEnvelope::ClientListDigest {
+                                digest,
+                                node_digest,
+                                node_count,
+                                ..
+                            }) => {
+                                let _ = tx.send((pid, digest, node_digest, node_count)).await;
                             }
                             _ => {
-                                let _ = tx.send((pid, vec![])).await;
+                                let _ = tx.send((pid, vec![], vec![], 0)).await;
                             }
                         },
                         Err(_) => {
-                            let _ = tx.send((pid, vec![])).await;
+                            let _ = tx.send((pid, vec![], vec![], 0)).await;
                         }
                     }
                 });
@@ -2621,8 +2637,8 @@ impl QuicNetworkManager {
         while received.len() < party_count - 1 {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             match tokio::time::timeout(remaining, rx.recv()).await {
-                Ok(Some((pid, digest))) => {
-                    received.insert(pid, digest);
+                Ok(Some((pid, digest, node_digest, node_count))) => {
+                    received.insert(pid, (digest, node_digest, node_count));
                 }
                 _ => {
                     return Err(ConsensusError::ConsensusTimeout {
@@ -2633,9 +2649,15 @@ impl QuicNetworkManager {
         }
 
         // 4. Verify all digests match
-        for (pid, digest) in &received {
+        for (pid, (digest, node_digest, node_count)) in &received {
             if *digest != local_digest {
                 return Err(ConsensusError::ClientListDigestMismatch { party_id: *pid });
+            }
+            if *node_count != node_keys.len() || *node_digest != local_node_digest {
+                return Err(ConsensusError::Aborted(format!(
+                    "Node list mismatch from party {}",
+                    pid
+                )));
             }
         }
 

--- a/src/transports/quic.rs
+++ b/src/transports/quic.rs
@@ -2571,6 +2571,23 @@ impl QuicNetworkManager {
                 "Local key not found in sorted keys".into(),
             ))? as PartyId;
         let client_keys = self.get_sorted_client_keys();
+        if let Some(expected_parties) = self.network_config.expected_parties {
+            if party_count != expected_parties {
+                return Err(ConsensusError::Aborted(format!(
+                    "Expected {} parties, found {}",
+                    expected_parties, party_count
+                )));
+            }
+        }
+        if let Some(expected_clients) = self.network_config.expected_clients {
+            if client_keys.len() != expected_clients {
+                return Err(ConsensusError::Aborted(format!(
+                    "Expected {} clients, found {}",
+                    expected_clients,
+                    client_keys.len()
+                )));
+            }
+        }
         let local_digest = self.compute_client_list_digest();
         let local_node_digest = self.compute_node_list_digest();
 
@@ -2589,14 +2606,34 @@ impl QuicNetworkManager {
             node_count: node_keys.len(),
         };
         let digest_bytes = digest_msg.serialize();
+        let mut send_tasks = tokio::task::JoinSet::new();
         for pid in 0..party_count {
             if pid == local_party_id {
                 continue;
             }
             if let Some(conn) = self.get_connection_by_party_id(pid) {
-                conn.send(&digest_bytes).await.map_err(|e| {
-                    ConsensusError::Aborted(format!("Send digest to party {}: {}", pid, e))
-                })?;
+                let bytes = digest_bytes.clone();
+                send_tasks.spawn(async move {
+                    conn.send(&bytes).await.map_err(|e| (pid, e))?;
+                    Ok::<PartyId, (PartyId, String)>(pid)
+                });
+            }
+        }
+        while let Some(result) = send_tasks.join_next().await {
+            match result {
+                Ok(Ok(_)) => {}
+                Ok(Err((pid, e))) => {
+                    return Err(ConsensusError::Aborted(format!(
+                        "Send digest to party {}: {}",
+                        pid, e
+                    )));
+                }
+                Err(e) => {
+                    return Err(ConsensusError::Aborted(format!(
+                        "Send digest task failed: {}",
+                        e
+                    )));
+                }
             }
         }
 
@@ -2613,18 +2650,20 @@ impl QuicNetworkManager {
                         Ok(data) => match NetEnvelope::try_deserialize(&data) {
                             Ok(NetEnvelope::ClientListDigest {
                                 digest,
+                                client_count,
                                 node_digest,
                                 node_count,
-                                ..
                             }) => {
-                                let _ = tx.send((pid, digest, node_digest, node_count)).await;
+                                let _ = tx
+                                    .send((pid, digest, client_count, node_digest, node_count))
+                                    .await;
                             }
                             _ => {
-                                let _ = tx.send((pid, vec![], vec![], 0)).await;
+                                let _ = tx.send((pid, vec![], 0, vec![], 0)).await;
                             }
                         },
                         Err(_) => {
-                            let _ = tx.send((pid, vec![], vec![], 0)).await;
+                            let _ = tx.send((pid, vec![], 0, vec![], 0)).await;
                         }
                     }
                 });
@@ -2637,8 +2676,8 @@ impl QuicNetworkManager {
         while received.len() < party_count - 1 {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             match tokio::time::timeout(remaining, rx.recv()).await {
-                Ok(Some((pid, digest, node_digest, node_count))) => {
-                    received.insert(pid, (digest, node_digest, node_count));
+                Ok(Some((pid, digest, client_count, node_digest, node_count))) => {
+                    received.insert(pid, (digest, client_count, node_digest, node_count));
                 }
                 _ => {
                     return Err(ConsensusError::ConsensusTimeout {
@@ -2649,8 +2688,8 @@ impl QuicNetworkManager {
         }
 
         // 4. Verify all digests match
-        for (pid, (digest, node_digest, node_count)) in &received {
-            if *digest != local_digest {
+        for (pid, (digest, client_count, node_digest, node_count)) in &received {
+            if *client_count != client_keys.len() || *digest != local_digest {
                 return Err(ConsensusError::ClientListDigestMismatch { party_id: *pid });
             }
             if *node_count != node_keys.len() || *node_digest != local_node_digest {
@@ -3268,6 +3307,76 @@ mod tests {
     fn ensure_crypto_provider() {
         // Install the default crypto provider (ring) if not already installed
         let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    #[derive(Clone)]
+    struct StaticPeerConnection {
+        response: Arc<Vec<u8>>,
+        sent: Arc<std::sync::Mutex<Vec<Vec<u8>>>>,
+        remote_addr: SocketAddr,
+        remote_party_id: Arc<std::sync::Mutex<Option<PartyId>>>,
+    }
+
+    impl StaticPeerConnection {
+        fn new(response: Vec<u8>) -> Self {
+            Self {
+                response: Arc::new(response),
+                sent: Arc::new(std::sync::Mutex::new(Vec::new())),
+                remote_addr: "127.0.0.1:0".parse().unwrap(),
+                remote_party_id: Arc::new(std::sync::Mutex::new(None)),
+            }
+        }
+    }
+
+    impl PeerConnection for StaticPeerConnection {
+        fn send<'a>(
+            &'a self,
+            data: &'a [u8],
+        ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
+            Box::pin(async move {
+                self.sent
+                    .lock()
+                    .map_err(|_| "sent lock poisoned".to_string())?
+                    .push(data.to_vec());
+                Ok(())
+            })
+        }
+
+        fn receive<'a>(
+            &'a self,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, String>> + Send + 'a>> {
+            Box::pin(async move { Ok((*self.response).clone()) })
+        }
+
+        fn remote_address(&self) -> SocketAddr {
+            self.remote_addr
+        }
+
+        fn close<'a>(&'a self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn state<'a>(&'a self) -> Pin<Box<dyn Future<Output = ConnectionState> + Send + 'a>> {
+            Box::pin(async move { ConnectionState::Connected })
+        }
+
+        fn is_connected<'a>(&'a self) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+            Box::pin(async move { true })
+        }
+
+        fn get_connection_role(&self) -> ClientType {
+            ClientType::Server
+        }
+
+        fn remote_party_id(&self) -> Option<PartyId> {
+            self.remote_party_id.lock().ok().and_then(|id| *id)
+        }
+
+        fn set_remote_party_id(&self, party_id: PartyId) {
+            if let Ok(mut id) = self.remote_party_id.lock() {
+                *id = Some(party_id);
+            }
+        }
     }
 
     // ========================================================================
@@ -5421,6 +5530,62 @@ mod tests {
             local_party_id,
             manager.compute_local_party_id().map(|id| id),
             "snapshot-derived party_id must match compute_local_party_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_consensus_rejects_unexpected_client_count() {
+        let mut manager = QuicNetworkManager::with_config(QuicNetworkConfig {
+            expected_parties: Some(1),
+            expected_clients: Some(0),
+            ..QuicNetworkConfig::default()
+        });
+        manager.local_public_key = Some(NodePublicKey(vec![1]));
+        manager
+            .client_public_keys
+            .insert(1, NodePublicKey(vec![10, 20, 30]));
+
+        let result = manager.execute_consensus(Duration::from_millis(100)).await;
+
+        assert!(matches!(
+            result,
+            Err(ConsensusError::Aborted(message))
+                if message == "Expected 0 clients, found 1"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_execute_consensus_rejects_peer_client_count_mismatch() {
+        let mut manager = QuicNetworkManager::with_config(QuicNetworkConfig {
+            expected_parties: Some(2),
+            expected_clients: Some(1),
+            ..QuicNetworkConfig::default()
+        });
+        let local_pk = NodePublicKey(vec![1]);
+        let peer_pk = NodePublicKey(vec![2]);
+        manager.local_public_key = Some(local_pk);
+        manager.peer_public_keys.insert(peer_pk.derive_id(), peer_pk.clone());
+        manager
+            .client_public_keys
+            .insert(1, NodePublicKey(vec![10, 20, 30]));
+
+        let peer_digest = NetEnvelope::ClientListDigest {
+            digest: manager.compute_client_list_digest(),
+            client_count: 2,
+            node_digest: manager.compute_node_list_digest(),
+            node_count: 2,
+        }
+        .serialize();
+        let peer_conn = StaticPeerConnection::new(peer_digest);
+        manager
+            .server_connections
+            .insert(peer_pk.derive_id(), Arc::new(peer_conn));
+
+        let result = manager.execute_consensus(Duration::from_millis(100)).await;
+
+        assert_eq!(
+            result,
+            Err(ConsensusError::ClientListDigestMismatch { party_id: 1 })
         );
     }
 }

--- a/src/transports/stun.rs
+++ b/src/transports/stun.rs
@@ -263,7 +263,7 @@ impl StunClient {
 
     /// Generates a random 12-byte transaction ID
     fn generate_transaction_id() -> [u8; 12] {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut id = [0u8; 12];
         rng.fill(&mut id);
         id
@@ -567,7 +567,7 @@ mod tests {
         BigEndian::write_u16(&mut attr[2..4], data.len() as u16);
         attr[4..].copy_from_slice(data);
         // Pad to 4-byte boundary if needed
-        while attr.len() % 4 != 0 {
+        while !attr.len().is_multiple_of(4) {
             attr.push(0);
         }
         attr

--- a/tests/nat_simulation/docker-compose.direct.yml
+++ b/tests/nat_simulation/docker-compose.direct.yml
@@ -1,0 +1,65 @@
+# Direct Container-to-Container Test (No NAT)
+# Tests if QUIC works between containers on the same network
+
+networks:
+  shared:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.100.0.0/24
+
+services:
+  signaling:
+    build:
+      context: ../..
+      dockerfile: tests/nat_simulation/Dockerfile.signaling
+    networks:
+      shared:
+        ipv4_address: 10.100.0.10
+    environment:
+      - RUST_LOG=info
+      - BIND_ADDR=0.0.0.0:9000
+
+  # Peer A - direct on shared network (no NAT)
+  peer_a:
+    build:
+      context: ../..
+      dockerfile: tests/nat_simulation/Dockerfile.peer
+    networks:
+      shared:
+        ipv4_address: 10.100.0.20
+    environment:
+      - RUST_LOG=info
+      - PEER_ID=1
+      - PEER_NAME=peer_a
+      - SIGNALING_SERVER=10.100.0.10:9000
+      - LOCAL_ADDR=0.0.0.0:5001
+    depends_on:
+      - signaling
+    command: >
+      sh -c "
+        sleep 2 &&
+        /app/nat_test_peer
+      "
+
+  # Peer B - direct on shared network (no NAT)
+  peer_b:
+    build:
+      context: ../..
+      dockerfile: tests/nat_simulation/Dockerfile.peer
+    networks:
+      shared:
+        ipv4_address: 10.100.0.21
+    environment:
+      - RUST_LOG=info
+      - PEER_ID=2
+      - PEER_NAME=peer_b
+      - SIGNALING_SERVER=10.100.0.10:9000
+      - LOCAL_ADDR=0.0.0.0:5002
+    depends_on:
+      - signaling
+    command: >
+      sh -c "
+        sleep 4 &&
+        /app/nat_test_peer
+      "

--- a/tests/nat_simulation/docker-compose.symmetric.yml
+++ b/tests/nat_simulation/docker-compose.symmetric.yml
@@ -1,0 +1,183 @@
+# Symmetric NAT Test
+#
+# Symmetric NAT assigns a DIFFERENT external port for each destination.
+# This makes hole punching nearly impossible without TURN relay.
+#
+# Expected result: ~0% success rate (hole punching should fail)
+
+networks:
+  public:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.100.0.0/24
+
+  private_a:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.101.0.0/24
+
+  private_b:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.102.0.0/24
+
+services:
+  signaling:
+    build:
+      context: ../..
+      dockerfile: tests/nat_simulation/Dockerfile.signaling
+    networks:
+      public:
+        ipv4_address: 10.100.0.10
+    environment:
+      - RUST_LOG=info
+      - BIND_ADDR=0.0.0.0:9000
+
+  stun:
+    build:
+      context: ../..
+      dockerfile: tests/nat_simulation/Dockerfile.stun
+    networks:
+      public:
+        ipv4_address: 10.100.0.11
+    environment:
+      - RUST_LOG=info
+      - BIND_ADDR=0.0.0.0:3478
+
+  # Symmetric NAT A - different external port per destination
+  nat_a:
+    image: alpine:latest
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      - net.ipv4.ip_forward=1
+      - net.netfilter.nf_conntrack_udp_timeout=120
+    networks:
+      public:
+        ipv4_address: 10.100.0.2
+      private_a:
+    command: >
+      sh -c "
+        apk add --no-cache iptables conntrack-tools &&
+
+        PUBLIC_IF=$$(ip -o addr show | grep '10\\.100\\.0\\.' | awk '{print $$2}') &&
+
+        # Symmetric NAT: Just MASQUERADE - Linux will assign random ports per destination
+        # No static SNAT, no DNAT - this creates symmetric NAT behavior
+        iptables -t nat -A POSTROUTING -o $$PUBLIC_IF -j MASQUERADE &&
+
+        # Allow forwarding
+        iptables -A FORWARD -j ACCEPT &&
+
+        echo 'Symmetric NAT A configured (MASQUERADE only, no static port mapping)' &&
+        iptables -t nat -L -v -n &&
+        tail -f /dev/null
+      "
+    healthcheck:
+      test: ["CMD", "sh", "-c", "iptables -t nat -L POSTROUTING | grep -q MASQUERADE"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  # Symmetric NAT B
+  nat_b:
+    image: alpine:latest
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      - net.ipv4.ip_forward=1
+      - net.netfilter.nf_conntrack_udp_timeout=120
+    networks:
+      public:
+        ipv4_address: 10.100.0.3
+      private_b:
+    command: >
+      sh -c "
+        apk add --no-cache iptables conntrack-tools &&
+
+        PUBLIC_IF=$$(ip -o addr show | grep '10\\.100\\.0\\.' | awk '{print $$2}') &&
+
+        # Symmetric NAT: Just MASQUERADE
+        iptables -t nat -A POSTROUTING -o $$PUBLIC_IF -j MASQUERADE &&
+
+        # Allow forwarding
+        iptables -A FORWARD -j ACCEPT &&
+
+        echo 'Symmetric NAT B configured (MASQUERADE only, no static port mapping)' &&
+        iptables -t nat -L -v -n &&
+        tail -f /dev/null
+      "
+    healthcheck:
+      test: ["CMD", "sh", "-c", "iptables -t nat -L POSTROUTING | grep -q MASQUERADE"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  peer_a:
+    build:
+      context: ../..
+      dockerfile: tests/nat_simulation/Dockerfile.peer
+    networks:
+      private_a:
+        ipv4_address: 10.101.0.10
+    environment:
+      - RUST_LOG=info
+      - PEER_ID=1
+      - PEER_NAME=peer_a
+      - SIGNALING_SERVER=10.100.0.10:9000
+      - STUN_SERVER=10.100.0.11:3478
+      - LOCAL_ADDR=0.0.0.0:5001
+    depends_on:
+      signaling:
+        condition: service_started
+      stun:
+        condition: service_started
+      nat_a:
+        condition: service_healthy
+    cap_add:
+      - NET_ADMIN
+    command: >
+      sh -c "
+        NAT_IP=$$(getent hosts nat_a | awk '{print $$1}' | head -1) &&
+        ip route del default || true &&
+        ip route add default via $$NAT_IP &&
+        sleep 3 &&
+        /app/nat_test_peer
+      "
+
+  peer_b:
+    build:
+      context: ../..
+      dockerfile: tests/nat_simulation/Dockerfile.peer
+    networks:
+      private_b:
+        ipv4_address: 10.102.0.10
+    environment:
+      - RUST_LOG=info
+      - PEER_ID=2
+      - PEER_NAME=peer_b
+      - SIGNALING_SERVER=10.100.0.10:9000
+      - STUN_SERVER=10.100.0.11:3478
+      - LOCAL_ADDR=0.0.0.0:5002
+    depends_on:
+      signaling:
+        condition: service_started
+      stun:
+        condition: service_started
+      nat_b:
+        condition: service_healthy
+    cap_add:
+      - NET_ADMIN
+    command: >
+      sh -c "
+        NAT_IP=$$(getent hosts nat_b | awk '{print $$1}' | head -1) &&
+        ip route del default || true &&
+        ip route add default via $$NAT_IP &&
+        sleep 5 &&
+        /app/nat_test_peer
+      "


### PR DESCRIPTION
### Motivation
- The in-network consensus previously validated only client-list digests, allowing honest nodes to mark consensus Ready while holding different node public-key orderings, which can break MPC party mappings.
- The change ensures nodes verify they all agree on the canonical ordered node list before unblocking sends, closing a high-severity attack surface where divergent `PartyId` mappings could leak or misdeliver secrets.

### Description
- Extend `NetEnvelope::ClientListDigest` to include `node_digest: Vec<u8>` and `node_count: usize` so node-to-node messages carry both client and node list digests and counts.
- Add `compute_node_list_digest()` to the QUIC manager and compute a local node-list digest alongside the client digest during consensus preparation.
- Include `node_digest`/`node_count` in the outbound digest message, parse those fields from peers, and reject consensus if any peer reports a different node digest or node count.
- Update `NetEnvelope` unit tests to exercise the expanded `ClientListDigest` shape and ensure round-trip serialization coverage.

### Testing
- Ran `cargo check -q` which completed successfully.
- Ran `cargo test -q --no-run` to validate tests compile against the new message shape and it completed successfully.
- Updated unit tests in `src/transports/net_envelope.rs` compile and cover the new `ClientListDigest` fields.